### PR TITLE
Add skills benchmark Docker setup

### DIFF
--- a/assist_tools/__init__.py
+++ b/assist_tools/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/assist_tools/skills_benchmark/.gitignore
+++ b/assist_tools/skills_benchmark/.gitignore
@@ -1,0 +1,4 @@
+/prompt.txt
+/results/
+__pycache__/
+*.py[cod]

--- a/assist_tools/skills_benchmark/__init__.py
+++ b/assist_tools/skills_benchmark/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/assist_tools/skills_benchmark/bin/build.sh
+++ b/assist_tools/skills_benchmark/bin/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+export PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+exec python3 -m assist_tools.skills_benchmark.skills.harness.host.build "$@"

--- a/assist_tools/skills_benchmark/config/agents/claude.yaml
+++ b/assist_tools/skills_benchmark/config/agents/claude.yaml
@@ -1,0 +1,145 @@
+# Agent profile contract
+#
+# Inputs:
+# - --model selects the measured model for direct runs; scenarios use
+#   agents[].models. requires_explicit_model=true means the run fails if the
+#   model is not selected explicitly.
+# - auth describes optional host files mounted into the container at runtime.
+# - launch defines the measured agent command. It must not contain prompt text;
+#   the harness supplies the prompt through stdin or a prompt file.
+# - skill_exposure defines how an already prepared SDK skills folder is exposed
+#   to this agent during with_skills runs.
+#
+# Outputs:
+# - images defines the Docker tags built and used by the harness.
+# - build.args are Docker build args. Values are profile-owned, not env-overridden.
+# - runtime_env/passthrough_env define container env passed to the agent process.
+# - final_message/events/usage/activity/exit define normalized run artifacts.
+#
+# Required sections:
+# name, display_name, agent_home_env, container_home, launch, skill_exposure,
+# final_message, events, usage, activity, and exit.
+#
+# Optional defaults:
+# default_model defaults to unspecified_default; images default to
+# agent-skills-benchmark:{agent}-skills/baseline/report; auth and passthrough
+# env may be omitted; availability_probe may be omitted.
+
+name: claude
+display_name: Claude Code
+default_model: unspecified_default
+requires_explicit_model: true
+agent_home_env: CLAUDE_CONFIG_DIR
+container_home: /workspace/.claude
+
+# Docker image tag outputs.
+images:
+  skills: agent-skills-benchmark:{agent}-skills
+  baseline: agent-skills-benchmark:{agent}-baseline
+  report: agent-skills-benchmark:{agent}-skills
+
+# Docker build inputs for the agent CLI layer and SDK skills setup target.
+build:
+  args:
+    BENCHMARK_DOCKER_AGENT: claude
+    BENCHMARK_AGENT_HOME: /workspace/.claude
+    AGENT_CLI_NAME: claude
+    AGENT_INSTALL_COMMAND: npm install -g "@anthropic-ai/claude-code@latest"
+    AGENT_VERSION_COMMAND: claude --version
+
+# Optional runtime auth inputs from the host.
+auth:
+  default_host_home: ~/.claude
+  mount_by_default: true
+  files:
+    - source: .credentials.json
+      target: .credentials.json
+      read_only: true
+      description: Claude credentials
+    - source: settings.json
+      target: settings.json
+      read_only: true
+      description: Claude settings
+
+# Runtime env outputs passed to the agent process.
+runtime_env:
+  CLAUDE_CONFIG_DIR: "{container_home}"
+
+passthrough_env:
+  - ANTHROPIC_API_KEY
+  - ANTHROPIC_AUTH_TOKEN
+  - ANTHROPIC_BASE_URL
+
+# Measured agent command input.
+launch:
+  prompt_input_mode: stdin
+  argv:
+    - claude
+    - --dangerously-skip-permissions
+    - --output-format
+    - stream-json
+    - --verbose
+    - --model
+    - "{model}"
+    - --print
+  sandbox_flags:
+    - --dangerously-skip-permissions
+  bypass_reason: "isolated benchmark container; writable state is limited to mounted result/workspace paths"
+  environment:
+    CLAUDE_CONFIG_DIR: "{container_home}"
+
+# Skills exposure input consumed during with_skills runs.
+skill_exposure:
+  mechanism_type: launch_flag
+  skill_root: "{container_home}/skills"
+  launch_args:
+    - --add-dir
+    - "{skills_dir}"
+
+# Normalized artifact outputs.
+final_message:
+  source_type: structured_event
+  event_selector:
+    type: result
+    subtype: success
+  parser: generic_structured_event_message
+  parser_warnings:
+    - "final message from last result event; may be truncated at context limit"
+
+events:
+  parser: claude_stream_json
+  format: stream-json
+
+usage:
+  parser: claude_stream_usage
+  fidelity: parsed
+  is_cumulative: false
+
+activity:
+  parser: claude_stream_activity
+
+exit:
+  classifier: stderr_patterns
+  rules:
+    - category: agent_cli_missing
+      exit_codes:
+        - 127
+    - category: agent_model_unsupported
+      all:
+        - model
+      any:
+        - not supported
+        - unsupported
+    - category: agent_auth_failure
+      any:
+        - auth
+        - api key
+        - login
+    - category: agent_sandbox_or_approval_failure
+      any:
+        - permission
+        - approval
+
+availability_probe:
+  - claude
+  - --version

--- a/assist_tools/skills_benchmark/config/agents/codex.yaml
+++ b/assist_tools/skills_benchmark/config/agents/codex.yaml
@@ -1,0 +1,141 @@
+# Agent profile contract
+#
+# Inputs:
+# - --model selects the measured model for direct runs; scenarios use
+#   agents[].models.
+# - auth describes optional host files mounted into the container at runtime.
+# - launch defines the measured agent command. It must not contain prompt text;
+#   the harness supplies the prompt through stdin or a prompt file.
+# - skill_exposure defines how an already prepared SDK skills folder is exposed
+#   to this agent during with_skills runs.
+#
+# Outputs:
+# - images defines the Docker tags built and used by the harness.
+# - build.args are Docker build args. Values are profile-owned, not env-overridden.
+# - runtime_env/passthrough_env define container env passed to the agent process.
+# - final_message/events/usage/activity/exit define normalized run artifacts.
+#
+# Required sections:
+# name, display_name, agent_home_env, container_home, launch, skill_exposure,
+# final_message, events, usage, activity, and exit.
+#
+# Optional defaults:
+# default_model defaults to unspecified_default; images default to
+# agent-skills-benchmark:{agent}-skills/baseline/report; auth and passthrough
+# env may be omitted; availability_probe may be omitted.
+
+name: codex
+display_name: OpenAI Codex CLI
+default_model: unspecified_default
+agent_home_env: CODEX_HOME
+container_home: /workspace/.codex
+legacy_artifact_prefixes:
+  - codex
+
+# Docker image tag outputs.
+images:
+  skills: agent-skills-benchmark:{agent}-skills
+  baseline: agent-skills-benchmark:{agent}-baseline
+  report: agent-skills-benchmark:{agent}-skills
+
+# Docker build inputs for the agent CLI layer and SDK skills setup target.
+build:
+  args:
+    BENCHMARK_DOCKER_AGENT: codex
+    BENCHMARK_AGENT_HOME: /workspace/.codex
+    AGENT_CLI_NAME: codex
+    AGENT_INSTALL_COMMAND: npm install -g "@openai/codex@0.137.0"
+    AGENT_VERSION_COMMAND: codex --version
+
+# Optional runtime auth inputs from the host.
+auth:
+  default_host_home: ~/.codex
+  mount_by_default: true
+  files:
+    - source: auth.json
+      target: auth.json
+      read_only: true
+      description: Codex auth
+    - source: config.toml
+      target: config.toml
+      read_only: true
+      description: Codex config
+
+# Runtime env outputs passed to the agent process.
+runtime_env:
+  CODEX_HOME: "{container_home}"
+
+passthrough_env:
+  - OPENAI_API_KEY
+
+# Measured agent command input.
+launch:
+  prompt_input_mode: stdin
+  argv:
+    - codex
+    - exec
+    - --json
+    - --skip-git-repo-check
+    - --dangerously-bypass-approvals-and-sandbox
+    - -C
+    - "{workspace_dir}"
+    - -o
+    - "{final_message_dest}"
+    - "-"
+  model_argv:
+    - -m
+    - "{model}"
+  model_argv_position: before_stdin_sentinel
+  sandbox_flags:
+    - --dangerously-bypass-approvals-and-sandbox
+  bypass_reason: "isolated benchmark container; writable state is limited to mounted result/workspace paths"
+  environment:
+    CODEX_HOME: "{container_home}"
+
+# Skills exposure input consumed during with_skills runs.
+skill_exposure:
+  mechanism_type: preinstalled_home
+  skill_root: "{container_home}/skills"
+  disable_packaged_source: true
+  metadata_files:
+    - "{container_home}/skills_build_install.json"
+    - "{container_home}/skills_list.json"
+
+# Normalized artifact outputs.
+final_message:
+  source_type: file
+  path: "{result_dir}/agent_last_message.txt"
+
+events:
+  parser: codex_jsonl
+  format: jsonl
+
+usage:
+  parser: codex_cumulative_usage
+  fidelity: parsed
+  is_cumulative: true
+
+activity:
+  parser: codex_jsonl_activity
+
+exit:
+  classifier: stderr_patterns
+  rules:
+    - category: agent_cli_missing
+      exit_codes:
+        - 127
+    - category: agent_model_unsupported
+      all:
+        - model
+      any:
+        - not supported
+        - unsupported
+    - category: agent_auth_failure
+      any:
+        - auth
+        - api key
+        - login
+
+availability_probe:
+  - codex
+  - --version

--- a/assist_tools/skills_benchmark/config/sdks/nvflare-profile.yaml
+++ b/assist_tools/skills_benchmark/config/sdks/nvflare-profile.yaml
@@ -1,0 +1,67 @@
+# SDK profile contract
+#
+# Inputs:
+# - source: where wheel inputs come from. source.type=repo requires source.path
+#   and markers; source.type=wheels requires source.wheels.skills/baseline.
+# - build: how skills/baseline wheels are prepared. build.type is required:
+#   uv_wheel builds with "uv build"; provided_wheels stages source.wheels.
+# - skills.setup: how SDK skills are installed in the skills image. type is
+#   required: command runs install_command; copy stages source_path; none skips.
+#
+# Outputs:
+# - dist/skills/*.whl and dist/baseline/*.whl in the Docker build context.
+# - SDK Docker build args for package/import/version checks and skills setup.
+# - ${BENCHMARK_AGENT_HOME}/skills plus install/list metadata in the skills image.
+#
+# Optional defaults:
+# - build.variants.<name>.label defaults to the variant name.
+# - build.env_name/build_env_value are only needed by SDKs with build toggles.
+# - skills.setup.install_output defaults to skills_build_install.json.
+# - skills.setup.list_output defaults to skills_list.json.
+# - skills.setup.expected_source defaults to local_sdk_wheel.
+
+name: nvflare
+display_name: NVIDIA FLARE
+package_name: nvflare
+import_name: nvflare
+
+# Required source input for build.type=uv_wheel.
+source:
+  type: repo
+  path: "{repo_root}"
+  markers:
+    - pyproject.toml
+    - nvflare/
+
+# Required wheel preparation contract.
+build:
+  type: uv_wheel
+  env_name: NVFLARE_PACKAGE_AGENT_SKILLS
+  variants:
+    skills:
+      label: skills
+      build_env_value: "1"
+      wheel_globs:
+        - nvflare-*.whl
+        - nvflare_nightly-*.whl
+      wheel_exclude_globs:
+        - "*no_skills*.whl"
+    baseline:
+      label: baseline
+      build_env_value: "0"
+      wheel_globs:
+        - "*no_skills*.whl"
+
+# Optional SDK verification run after wheel install.
+docker:
+  version_command: nvflare --version
+
+# Required skills setup contract for the skills image.
+skills:
+  setup:
+    type: command
+    install_command: nvflare --format json agent skills install --agent "${BENCHMARK_DOCKER_AGENT}" --target "${BENCHMARK_AGENT_HOME}/skills"
+    list_command: nvflare --format json agent skills list --agent "${BENCHMARK_DOCKER_AGENT}" --target "${BENCHMARK_AGENT_HOME}/skills"
+    install_output: skills_build_install.json
+    list_output: skills_list.json
+    expected_source: local_sdk_wheel

--- a/assist_tools/skills_benchmark/docker/Dockerfile
+++ b/assist_tools/skills_benchmark/docker/Dockerfile
@@ -1,0 +1,128 @@
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.19
+ARG NODE_IMAGE=node:22.16.0-bookworm-slim
+ARG BENCHMARK_DOCKER_AGENT=agent
+ARG BENCHMARK_AGENT_HOME=/workspace/agent-home
+ARG AGENT_CLI_NAME=agent
+ARG AGENT_INSTALL_COMMAND
+ARG AGENT_VERSION_COMMAND
+ARG SDK_PACKAGE_NAME=sdk
+ARG SDK_IMPORT_NAME
+ARG SDK_VERSION_COMMAND
+ARG SKILLS_SETUP_TYPE=command
+ARG SKILLS_INSTALL_COMMAND
+ARG SKILLS_LIST_COMMAND
+ARG SKILLS_INSTALL_OUTPUT=skills_build_install.json
+ARG SKILLS_LIST_OUTPUT=skills_list.json
+ARG SKILLS_INSTALL_EXPECTED_SOURCE=local_sdk_wheel
+
+FROM ${UV_IMAGE} AS uv_source
+
+FROM ${NODE_IMAGE} AS base
+ARG UV_IMAGE
+ARG NODE_IMAGE
+ARG BENCHMARK_DOCKER_AGENT
+ARG BENCHMARK_AGENT_HOME
+ARG AGENT_CLI_NAME
+ARG AGENT_INSTALL_COMMAND
+ARG AGENT_VERSION_COMMAND
+ARG SDK_PACKAGE_NAME
+ARG SDK_IMPORT_NAME
+ARG SDK_VERSION_COMMAND
+ARG SKILLS_SETUP_TYPE
+ARG SKILLS_INSTALL_COMMAND
+ARG SKILLS_LIST_COMMAND
+ARG SKILLS_INSTALL_OUTPUT
+ARG SKILLS_LIST_OUTPUT
+ARG SKILLS_INSTALL_EXPECTED_SOURCE
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    git \
+    python3 \
+    findutils \
+    coreutils \
+    tree \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN if [ -z "${AGENT_INSTALL_COMMAND}" ]; then \
+        echo "AGENT_INSTALL_COMMAND is required by the agent profile" >&2; \
+        exit 2; \
+    fi && \
+    /bin/bash -lc "${AGENT_INSTALL_COMMAND}" && \
+    if [ -n "${AGENT_VERSION_COMMAND}" ]; then /bin/bash -lc "${AGENT_VERSION_COMMAND}"; fi
+
+COPY --from=uv_source /uv /uvx /usr/local/bin/
+RUN uv --version
+
+ENV BENCHMARK_DOCKER_AGENT=${BENCHMARK_DOCKER_AGENT}
+ENV BENCHMARK_AGENT_HOME=${BENCHMARK_AGENT_HOME}
+ENV AGENT_CLI_NAME="${AGENT_CLI_NAME}"
+ENV AGENT_INSTALL_COMMAND="${AGENT_INSTALL_COMMAND}"
+ENV AGENT_VERSION_COMMAND="${AGENT_VERSION_COMMAND}"
+ENV SDK_PACKAGE_NAME="${SDK_PACKAGE_NAME}"
+ENV SDK_IMPORT_NAME="${SDK_IMPORT_NAME}"
+ENV SDK_VERSION_COMMAND="${SDK_VERSION_COMMAND}"
+ENV SKILLS_SETUP_TYPE="${SKILLS_SETUP_TYPE}"
+ENV SKILLS_INSTALL_COMMAND="${SKILLS_INSTALL_COMMAND}"
+ENV SKILLS_LIST_COMMAND="${SKILLS_LIST_COMMAND}"
+ENV SKILLS_INSTALL_OUTPUT="${SKILLS_INSTALL_OUTPUT}"
+ENV SKILLS_LIST_OUTPUT="${SKILLS_LIST_OUTPUT}"
+ENV SKILLS_INSTALL_EXPECTED_SOURCE="${SKILLS_INSTALL_EXPECTED_SOURCE}"
+ENV JOB_INPUT_DIR=/workspace/input
+ENV TRAINING_CODE=/workspace/input
+ENV RECORDS_DIR=/tmp/agent_benchmark/records
+
+WORKDIR /workspace
+RUN mkdir -p "${BENCHMARK_AGENT_HOME}" /workspace/prompts && \
+    uv venv --seed /workspace/venv
+
+ENV VIRTUAL_ENV=/workspace/venv
+ENV PATH="/workspace/venv/bin:/usr/local/bin:${PATH}"
+
+# Agent tool commands may use `bash -lc`; Debian /etc/profile resets PATH for login shells.
+RUN printf '%s\n' \
+    'export VIRTUAL_ENV=/workspace/venv' \
+    'case ":$PATH:" in *:/workspace/venv/bin:*) ;; *) export PATH="/workspace/venv/bin:$PATH" ;; esac' \
+    > /etc/profile.d/99-agent-benchmark-venv.sh && \
+    /bin/bash -lc 'command -v python && python --version && python -m pip --version && pip --version'
+
+RUN python --version && \
+    python -m pip --version && \
+    pip --version && \
+    tree --version && \
+    python -c "import json, os, pathlib, subprocess; version_cmd=os.environ.get('AGENT_VERSION_COMMAND') or ''; version_output=subprocess.check_output(['/bin/bash', '-lc', version_cmd], text=True).strip() if version_cmd else ''; home=pathlib.Path(os.environ.get('BENCHMARK_AGENT_HOME', '/workspace/agent-home')); home.mkdir(parents=True, exist_ok=True); home.joinpath('build_metadata.json').write_text(json.dumps({'agent': os.environ.get('BENCHMARK_DOCKER_AGENT', 'agent'), 'agent_cli': os.environ.get('AGENT_CLI_NAME', 'agent'), 'agent_cli_install_command': os.environ.get('AGENT_INSTALL_COMMAND'), 'agent_cli_version_command': version_cmd, 'agent_cli_version_output': version_output, 'apt_package_policy': 'Debian apt packages are intentionally not exact-version pinned; rebuild comparability is tracked through the pinned base image/build args and recorded package/tool versions.', 'node_image': os.environ.get('NODE_IMAGE'), 'node_version': subprocess.check_output(['node', '--version'], text=True).strip(), 'sdk_import_name': os.environ.get('SDK_IMPORT_NAME'), 'sdk_package_name': os.environ.get('SDK_PACKAGE_NAME'), 'skills_install_expected_source': os.environ.get('SKILLS_INSTALL_EXPECTED_SOURCE'), 'skills_install_network_proof': 'not_enforced_by_dockerfile', 'tree_version': subprocess.check_output(['tree', '--version'], text=True).splitlines()[0], 'uv_image': os.environ.get('UV_IMAGE'), 'uv_version': subprocess.check_output(['uv', '--version'], text=True).strip(), 'virtual_env': os.environ.get('VIRTUAL_ENV')}, indent=2, sort_keys=True) + '\n')"
+
+COPY assist_tools/ /workspace/assist_tools/
+CMD ["bash"]
+
+FROM base AS skills
+
+# Install the configured SDK from the staged local wheel that packages skills.
+COPY dist/skills/*.whl dist/skills/sdk_wheel_metadata.json /tmp/wheels/
+RUN python -c "import os, sys; from pathlib import Path; package=os.environ.get('SDK_PACKAGE_NAME', 'SDK'); wheels=sorted(Path('/tmp/wheels').glob('*.whl')); len(wheels) == 1 or sys.exit(f'Expected exactly one staged {package} skills wheel in /tmp/wheels, found {len(wheels)}: {[p.name for p in wheels]}'); Path('/tmp/selected_sdk_wheel').write_text(str(wheels[0]))" && \
+    wheel="$(cat /tmp/selected_sdk_wheel)" && \
+    uv pip install --python /workspace/venv/bin/python "${wheel}" && \
+    cp /tmp/wheels/sdk_wheel_metadata.json "${BENCHMARK_AGENT_HOME}/sdk_wheel_metadata.json" && \
+    rm -rf /tmp/wheels /tmp/selected_sdk_wheel && \
+    if [ -n "${SDK_VERSION_COMMAND}" ]; then /bin/bash -lc "${SDK_VERSION_COMMAND}"; fi && \
+    python -c "import importlib, os; name=os.environ.get('SDK_IMPORT_NAME'); importlib.import_module(name) if name else None" && \
+    /bin/bash -lc 'command -v python && python -m pip --version'
+
+# Preinstall skills so benchmark runs measure agent behavior, not skill setup time.
+COPY sdk_skills/ /tmp/sdk_skills/
+RUN python -m assist_tools.skills_benchmark.skills.harness.container.sdk_skills_setup
+
+FROM base AS baseline
+
+# Baseline image: install the configured SDK from the staged local wheel built without packaged skills.
+COPY dist/baseline/*.whl dist/baseline/sdk_wheel_metadata.json /tmp/wheels/
+RUN python -c "import os, sys; from pathlib import Path; package=os.environ.get('SDK_PACKAGE_NAME', 'SDK'); wheels=sorted(Path('/tmp/wheels').glob('*.whl')); len(wheels) == 1 or sys.exit(f'Expected exactly one staged {package} baseline wheel in /tmp/wheels, found {len(wheels)}: {[p.name for p in wheels]}'); Path('/tmp/selected_sdk_wheel').write_text(str(wheels[0]))" && \
+    wheel="$(cat /tmp/selected_sdk_wheel)" && \
+    uv pip install --python /workspace/venv/bin/python "${wheel}" && \
+    cp /tmp/wheels/sdk_wheel_metadata.json "${BENCHMARK_AGENT_HOME}/sdk_wheel_metadata.json" && \
+    rm -rf /tmp/wheels /tmp/selected_sdk_wheel && \
+    if [ -n "${SDK_VERSION_COMMAND}" ]; then /bin/bash -lc "${SDK_VERSION_COMMAND}"; fi && \
+    python -c "import importlib, os; name=os.environ.get('SDK_IMPORT_NAME'); importlib.import_module(name) if name else None" && \
+    /bin/bash -lc 'command -v python && python -m pip --version' && \
+    python -c "import json, os, pathlib; root=pathlib.Path(os.environ['BENCHMARK_AGENT_HOME']); agent=os.environ['BENCHMARK_DOCKER_AGENT']; reason=f'local baseline wheel does not package {agent} skills'; (root / os.environ['SKILLS_INSTALL_OUTPUT']).write_text(json.dumps({'status': 'skipped', 'agent': agent, 'reason': reason}, sort_keys=True) + '\n'); (root / os.environ['SKILLS_LIST_OUTPUT']).write_text(json.dumps({'status': 'skipped', 'agent': agent, 'installed': [], 'reason': reason}, sort_keys=True) + '\n')"

--- a/assist_tools/skills_benchmark/docker/build_context.dockerignore
+++ b/assist_tools/skills_benchmark/docker/build_context.dockerignore
@@ -1,0 +1,10 @@
+*
+!Dockerfile
+!assist_tools/
+!assist_tools/**
+assist_tools/**/__pycache__/
+assist_tools/**/*.pyc
+!dist/
+!dist/**
+!sdk_skills/
+!sdk_skills/**

--- a/assist_tools/skills_benchmark/skills/__init__.py
+++ b/assist_tools/skills_benchmark/skills/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NVIDIA skills benchmark tooling package."""

--- a/assist_tools/skills_benchmark/skills/harness/__init__.py
+++ b/assist_tools/skills_benchmark/skills/harness/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared Python helpers for the agent skills benchmark harness."""

--- a/assist_tools/skills_benchmark/skills/harness/agents/__init__.py
+++ b/assist_tools/skills_benchmark/skills/harness/agents/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/assist_tools/skills_benchmark/skills/harness/agents/base.py
+++ b/assist_tools/skills_benchmark/skills/harness/agents/base.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent adapter contracts for the benchmark harness."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class DockerMount:
+    host_path: Path
+    container_path: str
+    read_only: bool = True
+    description: str = ""
+    required: bool = False
+
+
+@dataclass(frozen=True)
+class AgentImageTargets:
+    skills: str
+    baseline: str
+    report: str
+
+
+@dataclass(frozen=True)
+class AgentLaunchSpec:
+    argv: list[str]
+    cwd: Path
+    prompt_file: Path
+    prompt_input_mode: str
+    stdout_events_dest: Path
+    stderr_dest: Path
+    final_message_dest: Path | None = None
+    environment: dict[str, str] = field(default_factory=dict)
+    login_shell: bool = False
+    approval_flags: list[str] = field(default_factory=list)
+    sandbox_flags: list[str] = field(default_factory=list)
+    bypass_reason: str | None = None
+    launch_timeout: int | None = None
+    extra_artifact_paths: list[Path] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SkillExposureSpec:
+    mechanism_type: str
+    container_home: Path | None = None
+    skill_root: Path | None = None
+    source_paths: list[Path] = field(default_factory=list)
+    setup_action: list[str] = field(default_factory=list)
+    probe_action: list[str] = field(default_factory=list)
+    disable_action: list[str] = field(default_factory=list)
+    launch_args: list[str] = field(default_factory=list)
+    environment: dict[str, str] = field(default_factory=dict)
+    metadata_files: list[Path] = field(default_factory=list)
+    expected_post_setup_state: str | None = None
+    disable_packaged_source: bool = False
+
+
+@dataclass(frozen=True)
+class SkillExposureResult:
+    status: str
+    mechanism_type: str
+    installed_paths: list[str] = field(default_factory=list)
+    disabled_paths: list[str] = field(default_factory=list)
+    launch_args: list[str] = field(default_factory=list)
+    environment: dict[str, str] = field(default_factory=dict)
+    probe_status: str | None = None
+    probe_output_ref: str | None = None
+    metadata_files: list[dict[str, str]] = field(default_factory=list)
+    parser_warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class FinalMessageSource:
+    source_type: str
+    path: Path | None = None
+    event_selector: dict[str, Any] | None = None
+    tail_bytes: int | None = None
+    parser: str | None = None
+    parser_warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class AgentLaunchContext:
+    workspace_dir: Path
+    prompt_file: Path
+    result_dir: Path
+    events_dest: Path
+    stderr_dest: Path
+    final_message_dest: Path
+    model: str
+    model_was_explicit: bool
+    timeout_seconds: int | None = None
+
+
+@dataclass(frozen=True)
+class SkillExposureContext:
+    result_dir: Path
+    container_home: Path
+    mode: str
+    skills_enabled: bool
+    sdk_image_kind: str
+
+
+class AgentAdapter(ABC):
+    """Contract for agent-specific benchmark mechanics.
+
+    The adapter starts and parses an agent surface. It must not construct,
+    edit, append, summarize, or reinterpret benchmark prompt content.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def default_model(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def agent_home_env(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def container_home(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def model_from_env(self, env: Mapping[str, str]) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def model_was_explicit(self, env: Mapping[str, str]) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def model_env_names(self) -> tuple[str, ...]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_args(self) -> dict[str, str]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def image_targets(self) -> AgentImageTargets:
+        raise NotImplementedError
+
+    @abstractmethod
+    def auth_mounts(self, host_config) -> list[DockerMount]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def runtime_env(self, config) -> dict[str, str]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def launch_spec(self, config: AgentLaunchContext) -> AgentLaunchSpec:
+        raise NotImplementedError
+
+    @abstractmethod
+    def skill_exposure(self, config: SkillExposureContext) -> SkillExposureSpec:
+        raise NotImplementedError
+
+    @abstractmethod
+    def availability_probe(self) -> list[str]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def normalize_event(self, raw_line: str) -> dict[str, Any] | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def parse_usage(self, events_path: Path) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def parse_activity(self, events_path: Path) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def final_message_source(self, result_dir: Path) -> FinalMessageSource:
+        raise NotImplementedError
+
+    @abstractmethod
+    def metadata(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def exit_summary(self, exit_code: int, stderr_path: Path) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def artifact_alias_prefixes(self) -> tuple[str, ...]:
+        return ()
+
+    def passthrough_env_names(self) -> tuple[str, ...]:
+        return ()
+
+    def host_home_from_env(self, env: Mapping[str, str]) -> Path:
+        return Path.home() / f".{self.name}"
+
+    def mount_auth_from_env(self, env: Mapping[str, str]) -> bool:
+        return True
+
+
+def normalize_agent_event(agent: str, raw_line: str) -> dict[str, Any] | None:
+    """Compatibility wrapper around the selected adapter's event normalizer."""
+
+    from .registry import get_agent_adapter
+
+    return get_agent_adapter(agent).normalize_event(raw_line)
+
+
+def validate_benchmark_agent(agent: str) -> str:
+    """Return a supported benchmark agent name or raise a clear error."""
+
+    from .registry import validate_benchmark_agent as _validate_benchmark_agent
+
+    return _validate_benchmark_agent(agent)

--- a/assist_tools/skills_benchmark/skills/harness/agents/classifiers.py
+++ b/assist_tools/skills_benchmark/skills/harness/agents/classifiers.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exit and failure classifiers for benchmark agent adapters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def stderr_excerpt(stderr_path: Path) -> str:
+    stderr_text = ""
+    try:
+        stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")[:4000]
+    except OSError:
+        pass
+    return stderr_text
+
+
+def generic_cli_exit(exit_code: int, stderr_path: Path, classifier_id: str = "generic_cli") -> dict[str, Any]:
+    stderr_text = stderr_excerpt(stderr_path)
+    return {
+        "classifier": classifier_id,
+        "exit_code": exit_code,
+        "passed": exit_code == 0,
+        "failure_category": "agent_unknown_failure" if exit_code else None,
+        "stderr_excerpt": stderr_text,
+    }
+
+
+EXIT_CLASSIFIERS = {"generic_cli", "stderr_patterns"}
+
+
+def validate_exit_classifier(classifier_id: str) -> None:
+    if classifier_id not in EXIT_CLASSIFIERS:
+        raise ValueError(f"Unknown agent exit classifier: {classifier_id}")
+
+
+def as_string_list(value: Any, field_path: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or any(not isinstance(item, str) or not item for item in value):
+        raise ValueError(f"{field_path} must be a list of non-empty strings")
+    return [str(item).lower() for item in value]
+
+
+def as_exit_codes(value: Any, field_path: str) -> set[int]:
+    if value is None:
+        return set()
+    if not isinstance(value, list) or any(isinstance(item, bool) or not isinstance(item, int) for item in value):
+        raise ValueError(f"{field_path} must be a list of integer exit codes")
+    return {int(item) for item in value}
+
+
+def validate_stderr_pattern_rules(config: dict[str, Any]) -> None:
+    rules = config.get("rules") or []
+    if not isinstance(rules, list):
+        raise ValueError("exit.rules must be a list")
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            raise ValueError(f"exit.rules[{index}] must be a mapping")
+        category = rule.get("category")
+        if not isinstance(category, str) or not category:
+            raise ValueError(f"exit.rules[{index}].category must be a non-empty string")
+        any_patterns = as_string_list(rule.get("any"), f"exit.rules[{index}].any")
+        all_patterns = as_string_list(rule.get("all"), f"exit.rules[{index}].all")
+        exit_codes = as_exit_codes(rule.get("exit_codes"), f"exit.rules[{index}].exit_codes")
+        if not any_patterns and not all_patterns and not exit_codes:
+            raise ValueError(f"exit.rules[{index}] must define at least one of any, all, or exit_codes")
+
+
+def validate_exit_config(config: dict[str, Any]) -> None:
+    classifier_id = str(config.get("classifier") or "")
+    validate_exit_classifier(classifier_id)
+    if classifier_id == "stderr_patterns":
+        validate_stderr_pattern_rules(config)
+
+
+def stderr_rule_matches(rule: dict[str, Any], exit_code: int, stderr_lower: str) -> bool:
+    if exit_code == 0:
+        return False
+    exit_codes = as_exit_codes(rule.get("exit_codes"), "exit.rules[].exit_codes")
+    if exit_codes and exit_code not in exit_codes:
+        return False
+    all_patterns = as_string_list(rule.get("all"), "exit.rules[].all")
+    if all_patterns and not all(pattern in stderr_lower for pattern in all_patterns):
+        return False
+    any_patterns = as_string_list(rule.get("any"), "exit.rules[].any")
+    if any_patterns and not any(pattern in stderr_lower for pattern in any_patterns):
+        return False
+    return bool(exit_codes or all_patterns or any_patterns)
+
+
+def stderr_pattern_exit(exit_code: int, stderr_path: Path, config: dict[str, Any]) -> dict[str, Any]:
+    summary = generic_cli_exit(exit_code, stderr_path, classifier_id="stderr_patterns")
+    stderr_lower = str(summary.get("stderr_excerpt") or "").lower()
+    for rule in config.get("rules") or []:
+        if stderr_rule_matches(rule, exit_code, stderr_lower):
+            summary["failure_category"] = str(rule["category"])
+            break
+    return summary
+
+
+def classify_exit(exit_code: int, stderr_path: Path, config: dict[str, Any]) -> dict[str, Any]:
+    validate_exit_config(config)
+    classifier_id = str(config.get("classifier") or "")
+    if classifier_id == "generic_cli":
+        return generic_cli_exit(exit_code, stderr_path)
+    if classifier_id == "stderr_patterns":
+        return stderr_pattern_exit(exit_code, stderr_path, config)
+    raise ValueError(f"Unknown agent exit classifier: {classifier_id}")

--- a/assist_tools/skills_benchmark/skills/harness/agents/config.py
+++ b/assist_tools/skills_benchmark/skills/harness/agents/config.py
@@ -1,0 +1,586 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""YAML-driven benchmark agent adapter implementation."""
+
+from __future__ import annotations
+
+import hashlib
+import string
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from .base import (
+    AgentAdapter,
+    AgentImageTargets,
+    AgentLaunchContext,
+    AgentLaunchSpec,
+    DockerMount,
+    FinalMessageSource,
+    SkillExposureContext,
+    SkillExposureSpec,
+)
+from .classifiers import classify_exit, validate_exit_config
+from .parsers import (
+    normalize_event_with_parser,
+    parse_activity_from_events,
+    parse_usage_from_events,
+    validate_activity_parser,
+    validate_event_parser,
+    validate_final_message_config,
+    validate_usage_parser,
+)
+
+PROMPT_TEXT_PLACEHOLDER = "prompt_text"
+UNSPECIFIED_MODEL = "unspecified_default"
+MODEL_ARGV_POSITION_BEFORE_STDIN_SENTINEL = "before_stdin_sentinel"
+MODEL_ARGV_POSITION_APPEND = "append"
+MODEL_ARGV_POSITIONS = {MODEL_ARGV_POSITION_BEFORE_STDIN_SENTINEL, MODEL_ARGV_POSITION_APPEND}
+LAUNCH_CONDITIONS = {"model_was_explicit"}
+SKILL_EXPOSURE_CONDITIONS: set[str] = set()
+SUPPORTED_SKILL_EXPOSURE_MECHANISMS = {"launch_flag", "none", "preinstalled_home"}
+
+
+def template_contains(value: Any, needle: str) -> bool:
+    if isinstance(value, str):
+        return needle in value
+    if isinstance(value, list):
+        return any(template_contains(item, needle) for item in value)
+    if isinstance(value, dict):
+        return any(template_contains(item, needle) for item in value.values())
+    return False
+
+
+def legacy_artifact_prefixes(data: Mapping[str, Any], config_path: Path) -> tuple[str, ...]:
+    prefixes = []
+    for item in data.get("legacy_artifact_prefixes") or ():
+        prefix = str(item)
+        if not prefix or Path(prefix).name != prefix:
+            raise ValueError(f"{config_path}: legacy_artifact_prefixes entries must be bare file prefixes: {prefix}")
+        prefixes.append(prefix)
+    return tuple(prefixes)
+
+
+def validate_when_conditions(values: Any, allowed: set[str], label: str, config_path: Path) -> None:
+    if isinstance(values, list):
+        for index, item in enumerate(values):
+            validate_when_conditions(item, allowed, f"{label}[{index}]", config_path)
+        return
+    if not isinstance(values, dict):
+        return
+    condition = values.get("when")
+    if condition is not None:
+        condition_name = str(condition)
+        if condition_name not in allowed:
+            allowed_text = ", ".join(sorted(allowed)) if allowed else "none"
+            raise ValueError(
+                f"{config_path}: {label}.when references unknown condition {condition_name!r}; "
+                f"allowed conditions: {allowed_text}"
+            )
+    validate_when_conditions(values.get("args") or [], allowed, f"{label}.args", config_path)
+
+
+@dataclass(frozen=True)
+class ParserConfig:
+    parser: str
+    fidelity: str | None = None
+    is_cumulative: bool | None = None
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    source_path: Path
+    raw: dict[str, Any]
+    source_sha256: str
+    name: str
+    display_name: str
+    default_model: str
+    model_env: str | None
+    requires_explicit_model: bool
+    agent_home_env: str
+    container_home: str
+    legacy_artifact_prefixes: tuple[str, ...]
+    images: dict[str, str]
+    auth: dict[str, Any]
+    launch: dict[str, Any]
+    skill_exposure: dict[str, Any]
+    final_message: dict[str, Any]
+    events: ParserConfig
+    usage: ParserConfig
+    activity: ParserConfig
+    exit_config: dict[str, Any]
+    exit_classifier: str
+    availability_probe: list[str] = field(default_factory=list)
+
+    @classmethod
+    def load(cls, config_path: Path) -> "AgentConfig":
+        source = config_path.read_text(encoding="utf-8")
+        if f"{{{PROMPT_TEXT_PLACEHOLDER}}}" in source:
+            raise ValueError(f"{config_path} must not use {{{PROMPT_TEXT_PLACEHOLDER}}}; use prompt_file delivery")
+        data = yaml.safe_load(source) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"{config_path} must contain a YAML object")
+        required = (
+            "name",
+            "display_name",
+            "agent_home_env",
+            "container_home",
+            "launch",
+            "skill_exposure",
+            "final_message",
+            "events",
+            "usage",
+            "activity",
+            "exit",
+        )
+        missing = [name for name in required if name not in data]
+        if missing:
+            raise ValueError(f"{config_path} is missing required field(s): {', '.join(missing)}")
+
+        launch = required_mapping(data, "launch", config_path)
+        if "argv" not in launch or not isinstance(launch["argv"], list):
+            raise ValueError(f"{config_path}: launch.argv must be a list")
+        prompt_input_mode = launch.get("prompt_input_mode")
+        if prompt_input_mode not in {"stdin", "file_arg"}:
+            raise ValueError(f"{config_path}: launch.prompt_input_mode must be stdin or file_arg")
+        if prompt_input_mode == "file_arg" and not template_contains(launch["argv"], "{prompt_file}"):
+            raise ValueError(f"{config_path}: launch.argv must include {{prompt_file}} for file_arg prompt delivery")
+        if launch.get("model_argv"):
+            model_position = str(launch.get("model_argv_position") or "")
+            if model_position not in MODEL_ARGV_POSITIONS:
+                raise ValueError(
+                    f"{config_path}: launch.model_argv_position must be one of: "
+                    f"{', '.join(sorted(MODEL_ARGV_POSITIONS))}"
+                )
+            if model_position == MODEL_ARGV_POSITION_BEFORE_STDIN_SENTINEL and (
+                prompt_input_mode != "stdin" or launch["argv"][-1:] != ["-"]
+            ):
+                raise ValueError(
+                    f"{config_path}: launch.model_argv_position={MODEL_ARGV_POSITION_BEFORE_STDIN_SENTINEL} "
+                    "requires stdin prompt delivery and launch.argv ending with '-'"
+                )
+            if model_position == MODEL_ARGV_POSITION_APPEND and prompt_input_mode == "stdin":
+                raise ValueError(
+                    f"{config_path}: launch.model_argv_position={MODEL_ARGV_POSITION_APPEND} is not valid with "
+                    "stdin prompt delivery; put model args directly in argv or use before_stdin_sentinel"
+                )
+        validate_when_conditions(launch["argv"], LAUNCH_CONDITIONS, "launch.argv", config_path)
+        validate_when_conditions(launch.get("model_argv") or [], LAUNCH_CONDITIONS, "launch.model_argv", config_path)
+        skill_exposure = required_mapping(data, "skill_exposure", config_path)
+        mechanism_type = str(skill_exposure.get("mechanism_type") or "none")
+        if mechanism_type not in SUPPORTED_SKILL_EXPOSURE_MECHANISMS:
+            raise ValueError(
+                f"{config_path}: skill_exposure.mechanism_type must be one of: "
+                f"{', '.join(sorted(SUPPORTED_SKILL_EXPOSURE_MECHANISMS))}"
+            )
+        for field_name in ("setup_action", "probe_action", "disable_action", "launch_args"):
+            validate_when_conditions(
+                skill_exposure.get(field_name) or [],
+                SKILL_EXPOSURE_CONDITIONS,
+                f"skill_exposure.{field_name}",
+                config_path,
+            )
+
+        events = parser_config(data, "events", config_path)
+        usage = parser_config(data, "usage", config_path)
+        activity = parser_config(data, "activity", config_path)
+        exit_config = required_mapping(data, "exit", config_path)
+        exit_classifier = str(exit_config.get("classifier") or "")
+        final_message = required_mapping(data, "final_message", config_path)
+        final_message_source_type = str(final_message.get("source_type") or "file")
+        final_message_parser = str(final_message["parser"]) if final_message.get("parser") else None
+        validate_event_parser(events.parser)
+        validate_usage_parser(usage.parser)
+        validate_activity_parser(activity.parser)
+        validate_exit_config(exit_config)
+        validate_final_message_config(final_message_source_type, final_message_parser)
+
+        return cls(
+            source_path=config_path,
+            raw=data,
+            source_sha256=hashlib.sha256(source.encode("utf-8")).hexdigest(),
+            name=str(data["name"]),
+            display_name=str(data["display_name"]),
+            default_model=str(data.get("default_model") or UNSPECIFIED_MODEL),
+            model_env=str(data["model_env"]) if data.get("model_env") else None,
+            requires_explicit_model=bool(data.get("requires_explicit_model", False)),
+            agent_home_env=str(data["agent_home_env"]),
+            container_home=str(data["container_home"]),
+            legacy_artifact_prefixes=legacy_artifact_prefixes(data, config_path),
+            images=dict(data.get("images") or {}),
+            auth=auth_config(data),
+            launch=launch,
+            skill_exposure=skill_exposure,
+            final_message=final_message,
+            events=events,
+            usage=usage,
+            activity=activity,
+            exit_config=exit_config,
+            exit_classifier=exit_classifier,
+            availability_probe=[str(item) for item in data.get("availability_probe") or []],
+        )
+
+
+def required_mapping(data: Mapping[str, Any], key: str, config_path: Path) -> dict[str, Any]:
+    value = data.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{config_path}: {key} must be a mapping")
+    return value
+
+
+def parser_config(data: Mapping[str, Any], key: str, config_path: Path) -> ParserConfig:
+    raw = required_mapping(data, key, config_path)
+    parser = raw.get("parser")
+    if not parser:
+        raise ValueError(f"{config_path}: {key}.parser is required")
+    return ParserConfig(
+        parser=str(parser),
+        fidelity=str(raw["fidelity"]) if raw.get("fidelity") else None,
+        is_cumulative=bool(raw["is_cumulative"]) if "is_cumulative" in raw else None,
+    )
+
+
+def template_fields(value: str) -> set[str]:
+    fields = set()
+    for _literal, field_name, _format_spec, _conversion in string.Formatter().parse(value):
+        if field_name is None:
+            continue
+        if field_name == "":
+            raise ValueError("Adapter templates must not use positional '{}' placeholders")
+        if "." in field_name or "[" in field_name or "]" in field_name:
+            raise ValueError("Adapter templates must not use attribute or index access")
+        fields.add(field_name)
+    return fields
+
+
+def render_string(value: str, values: Mapping[str, Any]) -> str:
+    fields = template_fields(value)
+    unknown = fields.difference(values)
+    if unknown:
+        raise ValueError(f"Unknown adapter template placeholder(s): {', '.join(sorted(unknown))}")
+    if PROMPT_TEXT_PLACEHOLDER in fields:
+        raise ValueError("Adapter templates must not reference prompt_text")
+    return value.format(**values)
+
+
+def auth_config(data: Mapping[str, Any]) -> dict[str, Any]:
+    auth = dict(data.get("auth") or {})
+    if "files" not in auth and isinstance(data.get("auth_mounts"), list):
+        auth["files"] = data["auth_mounts"]
+    return auth
+
+
+def render_list(values: list[Any], render_values: Mapping[str, Any]) -> list[str]:
+    rendered = []
+    for item in values:
+        if isinstance(item, dict):
+            condition = item.get("when")
+            if condition and not render_values.get(str(condition)):
+                continue
+            rendered.extend(render_list(list(item.get("args") or []), render_values))
+            continue
+        if not isinstance(item, str):
+            raise ValueError(f"Adapter argv/action entries must be strings; got {item!r}")
+        rendered.append(render_string(item, render_values))
+    return rendered
+
+
+def maybe_render_path(value: Any, render_values: Mapping[str, Any]) -> Path | None:
+    if not value:
+        return None
+    return Path(render_string(str(value), render_values))
+
+
+class ConfigurableAgentAdapter(AgentAdapter):
+    """Concrete adapter driven by a validated YAML config."""
+
+    def __init__(self, config_path: Path) -> None:
+        self._cfg = AgentConfig.load(config_path)
+
+    @property
+    def name(self) -> str:
+        return self._cfg.name
+
+    @property
+    def display_name(self) -> str:
+        return self._cfg.display_name
+
+    @property
+    def default_model(self) -> str:
+        return self._cfg.default_model
+
+    @property
+    def agent_home_env(self) -> str:
+        return self._cfg.agent_home_env
+
+    @property
+    def container_home(self) -> str:
+        return self._cfg.container_home
+
+    def model_from_env(self, env: Mapping[str, str]) -> str:
+        explicit_model = env.get("BENCHMARK_AGENT_MODEL") or (
+            env.get(self._cfg.model_env) if self._cfg.model_env else None
+        )
+        if explicit_model:
+            return explicit_model
+        if self._cfg.requires_explicit_model:
+            accepted = ["BENCHMARK_AGENT_MODEL"]
+            if self._cfg.model_env:
+                accepted.append(self._cfg.model_env)
+            raise ValueError(
+                f"{self.display_name} requires an explicit benchmark model. " f"Set one of: {', '.join(accepted)}."
+            )
+        return self.default_model or UNSPECIFIED_MODEL
+
+    def model_was_explicit(self, env: Mapping[str, str]) -> bool:
+        return bool(env.get("BENCHMARK_AGENT_MODEL") or (env.get(self._cfg.model_env) if self._cfg.model_env else None))
+
+    def model_env_names(self) -> tuple[str, ...]:
+        return (self._cfg.model_env,) if self._cfg.model_env else ()
+
+    def build_args(self) -> dict[str, str]:
+        build = self._cfg.raw.get("build") or {}
+        if not isinstance(build, dict):
+            return {}
+        args = {}
+        for key, value in (build.get("args") or {}).items():
+            if isinstance(value, dict):
+                raise ValueError(f"{self._cfg.source_path}: build.args.{key} must be a scalar profile value")
+            else:
+                args[str(key)] = render_string(str(value), {"agent": self.name})
+        return args
+
+    def image_targets(self) -> AgentImageTargets:
+        render_values = {"agent": self.name}
+        skills = render_string(
+            str(self._cfg.images.get("skills") or "agent-skills-benchmark:{agent}-skills"), render_values
+        )
+        baseline = render_string(
+            str(self._cfg.images.get("baseline") or "agent-skills-benchmark:{agent}-baseline"), render_values
+        )
+        report = render_string(str(self._cfg.images.get("report") or skills), render_values)
+        return AgentImageTargets(
+            skills=skills,
+            baseline=baseline,
+            report=report,
+        )
+
+    def auth_mounts(self, host_config) -> list[DockerMount]:
+        auth = self._cfg.auth
+        if not auth:
+            return []
+        host_home = Path(getattr(host_config, "host_agent_home", Path.home()))
+        mounts = []
+        for item in auth.get("files") or []:
+            if not isinstance(item, dict):
+                continue
+            source_name = str(item.get("source") or "")
+            target_name = str(item.get("target") or source_name)
+            if not source_name or not target_name:
+                continue
+            if Path(source_name).name != source_name:
+                raise ValueError(f"{self._cfg.source_path}: auth file source must be a file name: {source_name}")
+            if Path(target_name).name != target_name:
+                raise ValueError(f"{self._cfg.source_path}: auth file target must be a file name: {target_name}")
+            mounts.append(
+                DockerMount(
+                    host_path=host_home / source_name,
+                    container_path=f"{self.container_home.rstrip('/')}/{target_name}",
+                    read_only=bool(item.get("read_only", True)),
+                    description=str(item.get("description") or f"{self.display_name} auth/config"),
+                    required=bool(item.get("required", False)),
+                )
+            )
+        return mounts
+
+    def host_home_from_env(self, env: Mapping[str, str]) -> Path:
+        auth = self._cfg.auth if self._cfg.auth else {}
+        host_home_env = auth.get("host_home_env")
+        if host_home_env and env.get(str(host_home_env)):
+            return Path(str(env[str(host_home_env)])).expanduser()
+        default_host_home = auth.get("default_host_home")
+        if default_host_home:
+            return Path(str(default_host_home)).expanduser()
+        return Path.home() / f".{self.name}"
+
+    def mount_auth_from_env(self, env: Mapping[str, str]) -> bool:
+        auth = self._cfg.auth if self._cfg.auth else {}
+        mount_env = auth.get("mount_env")
+        if not mount_env or str(mount_env) not in env:
+            return bool(auth.get("mount_by_default", True))
+        value = env[str(mount_env)]
+        if value not in {"true", "false"}:
+            raise ValueError(f"{mount_env} must be true or false; got {value}")
+        return value == "true"
+
+    def runtime_env(self, config) -> dict[str, str]:
+        env = {
+            self.agent_home_env: self.container_home,
+            "BENCHMARK_AGENT_HOME": self.container_home,
+            "BENCHMARK_AGENT": self.name,
+        }
+        model_was_explicit = getattr(config, "model_was_explicit", None)
+        if model_was_explicit is None:
+            model_was_explicit = getattr(config, "agent_model_was_explicit", False)
+        if self._cfg.requires_explicit_model and not model_was_explicit:
+            accepted = ["BENCHMARK_AGENT_MODEL"]
+            if self._cfg.model_env:
+                accepted.append(self._cfg.model_env)
+            raise ValueError(
+                f"{self.display_name} requires an explicit benchmark model before runtime setup. "
+                f"Set one of: {', '.join(accepted)}."
+            )
+        if model_was_explicit:
+            env["BENCHMARK_AGENT_MODEL"] = getattr(config, "agent_model", self.default_model)
+        for key, value in (self._cfg.raw.get("runtime_env") or {}).items():
+            env[str(key)] = render_string(str(value), {"container_home": self.container_home, "agent": self.name})
+        return env
+
+    def passthrough_env_names(self) -> tuple[str, ...]:
+        return tuple(str(item) for item in self._cfg.raw.get("passthrough_env") or ())
+
+    def launch_spec(self, config: AgentLaunchContext) -> AgentLaunchSpec:
+        if self._cfg.requires_explicit_model and not config.model_was_explicit:
+            accepted = ["BENCHMARK_AGENT_MODEL"]
+            if self._cfg.model_env:
+                accepted.append(self._cfg.model_env)
+            raise ValueError(
+                f"{self.display_name} requires an explicit benchmark model before launch. "
+                f"Set one of: {', '.join(accepted)}."
+            )
+        final_message_dest = config.final_message_dest
+        render_values = {
+            "agent": self.name,
+            "model": config.model,
+            "workspace_dir": str(config.workspace_dir),
+            "prompt_file": str(config.prompt_file),
+            "result_dir": str(config.result_dir),
+            "events_dest": str(config.events_dest),
+            "stderr_dest": str(config.stderr_dest),
+            "final_message_dest": str(final_message_dest),
+            "container_home": self.container_home,
+            "model_was_explicit": config.model_was_explicit,
+        }
+        argv = render_list(list(self._cfg.launch["argv"]), render_values)
+        if config.model_was_explicit and self._cfg.launch.get("model_argv"):
+            model_argv = render_list(list(self._cfg.launch["model_argv"]), render_values)
+            model_position = str(self._cfg.launch["model_argv_position"])
+            if model_position == MODEL_ARGV_POSITION_BEFORE_STDIN_SENTINEL:
+                argv = [*argv[:-1], *model_argv, argv[-1]]
+            elif model_position == MODEL_ARGV_POSITION_APPEND:
+                argv.extend(model_argv)
+            else:
+                raise ValueError(f"Unsupported launch.model_argv_position: {model_position}")
+        env = {}
+        for key, value in (self._cfg.launch.get("environment") or {}).items():
+            env[str(key)] = render_string(str(value), render_values)
+        env.update({self.agent_home_env: self.container_home})
+        return AgentLaunchSpec(
+            argv=argv,
+            cwd=config.workspace_dir,
+            prompt_file=config.prompt_file,
+            prompt_input_mode=str(self._cfg.launch["prompt_input_mode"]),
+            stdout_events_dest=config.events_dest,
+            stderr_dest=config.stderr_dest,
+            final_message_dest=final_message_dest,
+            environment=env,
+            login_shell=bool(self._cfg.launch.get("login_shell", False)),
+            approval_flags=[str(item) for item in self._cfg.launch.get("approval_flags") or []],
+            sandbox_flags=[str(item) for item in self._cfg.launch.get("sandbox_flags") or []],
+            bypass_reason=str(self._cfg.launch.get("bypass_reason")) if self._cfg.launch.get("bypass_reason") else None,
+            launch_timeout=config.timeout_seconds,
+        )
+
+    def skill_exposure(self, config: SkillExposureContext) -> SkillExposureSpec:
+        render_values = {
+            "agent": self.name,
+            "container_home": str(config.container_home),
+            "result_dir": str(config.result_dir),
+            "skills_dir": str(config.container_home / "skills"),
+        }
+        raw = self._cfg.skill_exposure
+        return SkillExposureSpec(
+            mechanism_type=str(raw.get("mechanism_type") or "none"),
+            container_home=config.container_home,
+            skill_root=maybe_render_path(raw.get("skill_root"), render_values),
+            source_paths=[Path(render_string(str(item), render_values)) for item in raw.get("source_paths") or []],
+            setup_action=render_list(list(raw.get("setup_action") or []), render_values),
+            probe_action=render_list(list(raw.get("probe_action") or []), render_values),
+            disable_action=render_list(list(raw.get("disable_action") or []), render_values),
+            launch_args=render_list(list(raw.get("launch_args") or []), render_values),
+            environment={
+                str(key): render_string(str(value), render_values)
+                for key, value in (raw.get("environment") or {}).items()
+            },
+            metadata_files=[Path(render_string(str(item), render_values)) for item in raw.get("metadata_files") or []],
+            expected_post_setup_state=(
+                str(raw.get("expected_post_setup_state")) if raw.get("expected_post_setup_state") else None
+            ),
+            disable_packaged_source=bool(raw.get("disable_packaged_source", False)),
+        )
+
+    def availability_probe(self) -> list[str]:
+        return list(self._cfg.availability_probe)
+
+    def normalize_event(self, raw_line: str) -> dict[str, Any] | None:
+        return normalize_event_with_parser(raw_line, self._cfg.events.parser)
+
+    def parse_usage(self, events_path: Path) -> dict[str, Any]:
+        usage = parse_usage_from_events(events_path, self._cfg.usage)
+        if self._cfg.usage.fidelity:
+            usage.setdefault("usage_fidelity", self._cfg.usage.fidelity)
+        if self._cfg.usage.is_cumulative is not None:
+            usage.setdefault("is_cumulative", self._cfg.usage.is_cumulative)
+        return usage
+
+    def parse_activity(self, events_path: Path) -> dict[str, Any]:
+        return parse_activity_from_events(events_path, self._cfg.activity)
+
+    def final_message_source(self, result_dir: Path) -> FinalMessageSource:
+        render_values = {"result_dir": str(result_dir), "agent": self.name}
+        source_type = str(self._cfg.final_message.get("source_type") or "file")
+        return FinalMessageSource(
+            source_type=source_type,
+            path=maybe_render_path(self._cfg.final_message.get("path"), render_values),
+            event_selector=(
+                dict(self._cfg.final_message["event_selector"])
+                if isinstance(self._cfg.final_message.get("event_selector"), dict)
+                else None
+            ),
+            tail_bytes=(
+                int(self._cfg.final_message["tail_bytes"])
+                if self._cfg.final_message.get("tail_bytes") is not None
+                else None
+            ),
+            parser=str(self._cfg.final_message["parser"]) if self._cfg.final_message.get("parser") else None,
+            parser_warnings=[str(item) for item in self._cfg.final_message.get("parser_warnings") or []],
+        )
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "agent": self.name,
+            "display_name": self.display_name,
+            "config_path": str(self._cfg.source_path),
+            "config_sha256": self._cfg.source_sha256,
+            "adapter_type": "ConfigurableAgentAdapter",
+        }
+
+    def exit_summary(self, exit_code: int, stderr_path: Path) -> dict[str, Any]:
+        return classify_exit(exit_code, stderr_path, self._cfg.exit_config)
+
+    def artifact_alias_prefixes(self) -> tuple[str, ...]:
+        return self._cfg.legacy_artifact_prefixes

--- a/assist_tools/skills_benchmark/skills/harness/agents/parsers.py
+++ b/assist_tools/skills_benchmark/skills/harness/agents/parsers.py
@@ -1,0 +1,398 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parser registries for YAML-driven benchmark agent adapters."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from ..events import parse_timestamp, parse_usage_and_activity_data
+
+MAX_ACTIVITY_COMMANDS = 200
+CLAUDE_SHELL_TOOL_NAMES = {"bash"}
+
+
+def event_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def normalize_jsonl_event(raw_line: str) -> dict[str, Any] | None:
+    stripped = raw_line.rstrip("\n")
+    if not stripped:
+        return None
+    timestamp = event_timestamp()
+    try:
+        event = json.loads(stripped)
+    except json.JSONDecodeError:
+        event = {"type": "harness.unparsed_event", "raw": stripped}
+    if isinstance(event, dict):
+        event.setdefault("timestamp", timestamp)
+        event["harness_timestamp"] = timestamp
+        return event
+    return {
+        "type": "harness.non_object_event",
+        "timestamp": timestamp,
+        "harness_timestamp": timestamp,
+        "value": event,
+    }
+
+
+def normalize_claude_stream_event(raw_line: str) -> dict[str, Any] | None:
+    event = normalize_jsonl_event(raw_line)
+    if event is None:
+        return None
+    if event.get("type", "").startswith("harness."):
+        event.setdefault("event_type", event.get("type"))
+        return event
+
+    event_type = str(event.get("type") or "unknown")
+    subtype = event.get("subtype")
+    event["event_type"] = f"{event_type}.{subtype}" if subtype else event_type
+    if event_type == "result" and isinstance(event.get("result"), str):
+        event["final_message"] = event["result"]
+    # Neutral events expose one primary tool per raw event. Keep the first
+    # shell-tool command as the stable activity signal for report aggregation.
+    for tool_use in claude_tool_uses(event):
+        event.setdefault("tool_kind", tool_use.get("name"))
+        command = claude_tool_command(tool_use)
+        if command:
+            event.setdefault("command_text", command)
+            break
+    return event
+
+
+def claude_message_content(event: dict[str, Any]) -> list[Any]:
+    message = event.get("message")
+    if not isinstance(message, dict):
+        return []
+    content = message.get("content")
+    return content if isinstance(content, list) else []
+
+
+def claude_tool_uses(event: dict[str, Any]) -> list[dict[str, Any]]:
+    return [item for item in claude_message_content(event) if isinstance(item, dict) and item.get("type") == "tool_use"]
+
+
+def claude_tool_command(tool_use: dict[str, Any]) -> str | None:
+    tool_name = str(tool_use.get("name") or "").lower()
+    if tool_name not in CLAUDE_SHELL_TOOL_NAMES:
+        return None
+    tool_input = tool_use.get("input")
+    if not isinstance(tool_input, dict):
+        return None
+    for key in ("command", "cmd", "shell_command"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def numeric_token_field(data: dict[str, Any], key: str) -> float:
+    value = data.get(key)
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else 0.0
+
+
+def claude_usage_total(usage: dict[str, Any]) -> float:
+    # Claude cache write/read token fields are included in the headline total
+    # because they contribute to run cost; the neutral cache_tokens field also
+    # exposes them separately for report layers that split cache cost.
+    return sum(
+        numeric_token_field(usage, key)
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+        )
+    )
+
+
+def claude_usage_has_tokens(usage: dict[str, Any]) -> bool:
+    return any(
+        numeric_token_field(usage, key) > 0
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+        )
+    )
+
+
+def claude_usage_objects(event: dict[str, Any]) -> list[dict[str, Any]]:
+    usage_objects = []
+    usage = event.get("usage")
+    if isinstance(usage, dict):
+        usage_objects.append(usage)
+    message = event.get("message")
+    if isinstance(message, dict) and isinstance(message.get("usage"), dict):
+        usage_objects.append(message["usage"])
+    return usage_objects
+
+
+def iter_json_events(events_path: Path) -> tuple[list[dict[str, Any]], int]:
+    events = []
+    decode_errors = 0
+    if not events_path.exists():
+        return events, decode_errors
+    with events_path.open("r", encoding="utf-8", errors="replace") as stream:
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                decode_errors += 1
+                continue
+            if isinstance(event, dict):
+                events.append(event)
+    return events, decode_errors
+
+
+def parse_claude_stream_usage(events_path: Path) -> dict[str, Any]:
+    events, decode_errors = iter_json_events(events_path)
+    result_usage: dict[str, Any] | None = None
+    result_usage_count = 0
+    summed = {
+        "input_tokens": 0.0,
+        "output_tokens": 0.0,
+        "cache_creation_input_tokens": 0.0,
+        "cache_read_input_tokens": 0.0,
+    }
+    usage_objects_seen = 0
+    total_cost_usd = None
+    for event in events:
+        if event.get("type") == "result" and isinstance(event.get("usage"), dict):
+            usage_objects_seen += 1
+            result_usage_count += 1
+            if result_usage is not None:
+                for key in summed:
+                    summed[key] += numeric_token_field(result_usage, key)
+            result_usage = event["usage"]
+            if isinstance(event.get("message"), dict) and isinstance(event["message"].get("usage"), dict):
+                usage_objects_seen += 1
+            if isinstance(event.get("total_cost_usd"), (int, float)):
+                total_cost_usd = event.get("total_cost_usd")
+            continue
+        if event.get("type") == "result" and isinstance(event.get("total_cost_usd"), (int, float)):
+            total_cost_usd = event.get("total_cost_usd")
+        for usage in claude_usage_objects(event):
+            usage_objects_seen += 1
+            for key in summed:
+                summed[key] += numeric_token_field(usage, key)
+
+    if result_usage is not None and claude_usage_has_tokens(result_usage):
+        selected = result_usage
+    else:
+        selected = summed
+    total_tokens = claude_usage_total(selected)
+    parser_warnings = []
+    if usage_objects_seen == 0:
+        parser_warnings.append("No Claude usage objects were found in the stream-json events.")
+        total_tokens = None
+    elif result_usage is None:
+        parser_warnings.append(
+            "No Claude result usage object was found; token fields are summed from message usage objects."
+        )
+    elif not claude_usage_has_tokens(result_usage) and claude_usage_has_tokens(summed):
+        parser_warnings.append(
+            "Claude result usage object had no nonzero token fields; token fields are summed from message usage objects."
+        )
+    elif result_usage_count > 1:
+        parser_warnings.append(
+            "Multiple Claude result usage objects were found; final cumulative result usage was used."
+        )
+    cache_creation_tokens = selected.get("cache_creation_input_tokens")
+    cache_read_tokens = selected.get("cache_read_input_tokens")
+    cache_tokens = numeric_token_field(selected, "cache_creation_input_tokens") + numeric_token_field(
+        selected, "cache_read_input_tokens"
+    )
+    return {
+        "total_tokens": total_tokens,
+        "input_tokens": selected.get("input_tokens"),
+        "output_tokens": selected.get("output_tokens"),
+        "cache_tokens": cache_tokens,
+        "cost": total_cost_usd,
+        "parser_warnings": parser_warnings,
+        "cache_creation_input_tokens": selected.get("cache_creation_input_tokens"),
+        "cache_read_input_tokens": selected.get("cache_read_input_tokens"),
+        "raw_cache_creation_input_tokens": cache_creation_tokens,
+        "raw_cache_read_input_tokens": cache_read_tokens,
+        "total_cost_usd": total_cost_usd,
+        "json_decode_errors": decode_errors,
+        "usage_objects_seen": usage_objects_seen,
+        "result_usage_objects_seen": result_usage_count,
+        "token_parser": "Claude stream-json result usage; fallback sums message usage objects",
+    }
+
+
+def parse_claude_stream_activity(events_path: Path) -> dict[str, Any]:
+    events, decode_errors = iter_json_events(events_path)
+    event_types: Counter[str] = Counter()
+    tool_counts: Counter[str] = Counter()
+    command_prefixes: Counter[str] = Counter()
+    commands: list[str] = []
+    unique_commands_seen: set[str] = set()
+    first_event_dt = None
+    first_event_timestamp = None
+    last_event_dt = None
+    last_event_timestamp = None
+    previous_event_dt = None
+    max_inter_event_gap_seconds = None
+    for event in events:
+        event_type = str(event.get("event_type") or event.get("type") or "unknown")
+        event_types[event_type] += 1
+        timestamp = event.get("harness_timestamp") or event.get("timestamp")
+        event_dt = parse_timestamp(timestamp)
+        if event_dt is not None:
+            if first_event_dt is None:
+                first_event_dt = event_dt
+                first_event_timestamp = timestamp
+            if previous_event_dt is not None:
+                gap = (event_dt - previous_event_dt).total_seconds()
+                if gap >= 0 and (max_inter_event_gap_seconds is None or gap > max_inter_event_gap_seconds):
+                    max_inter_event_gap_seconds = gap
+            previous_event_dt = event_dt
+            last_event_dt = event_dt
+            last_event_timestamp = timestamp
+        command = event.get("command_text")
+        tool_kind = event.get("tool_kind")
+        if isinstance(tool_kind, str) and tool_kind:
+            tool_counts[tool_kind] += 1
+        if isinstance(command, str) and command.strip():
+            command = command.strip()
+            if len(commands) < MAX_ACTIVITY_COMMANDS:
+                commands.append(command)
+            unique_commands_seen.add(command)
+            command_prefixes[command.split()[0]] += 1
+
+    return {
+        "event_count": len(events),
+        "json_decode_errors": decode_errors,
+        "timestamp_field": "harness_timestamp",
+        "first_event_timestamp": first_event_timestamp,
+        "last_event_timestamp": last_event_timestamp,
+        "event_span_seconds": (
+            round((last_event_dt - first_event_dt).total_seconds(), 3)
+            if first_event_dt is not None and last_event_dt is not None
+            else None
+        ),
+        "max_inter_event_gap_seconds": (
+            round(max_inter_event_gap_seconds, 3) if max_inter_event_gap_seconds is not None else None
+        ),
+        "event_types": dict(event_types.most_common()),
+        "tool_counts": dict(tool_counts.most_common()),
+        "command_count": sum(command_prefixes.values()),
+        "unique_command_count": len(unique_commands_seen),
+        "command_prefix_counts": dict(command_prefixes.most_common()),
+        "commands": commands,
+        "commands_truncated": sum(command_prefixes.values()) > len(commands),
+        "max_recorded_commands": MAX_ACTIVITY_COMMANDS,
+    }
+
+
+@lru_cache(maxsize=32)
+def parse_cached_usage_and_activity(events_path: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    return parse_usage_and_activity_data(Path(events_path))
+
+
+def cached_usage(events_path: Path) -> dict[str, Any]:
+    usage, _activity = parse_cached_usage_and_activity(str(events_path))
+    return dict(usage)
+
+
+def cached_activity(events_path: Path) -> dict[str, Any]:
+    _usage, activity = parse_cached_usage_and_activity(str(events_path))
+    return dict(activity)
+
+
+EVENT_PARSERS = {
+    "claude_stream_json": normalize_claude_stream_event,
+    "codex_jsonl": normalize_jsonl_event,
+    "generic_jsonl": normalize_jsonl_event,
+}
+
+USAGE_PARSERS = {
+    "claude_stream_usage": parse_claude_stream_usage,
+    "codex_cumulative_usage": cached_usage,
+    "generic_cli_usage": cached_usage,
+}
+
+ACTIVITY_PARSERS = {
+    "claude_stream_activity": parse_claude_stream_activity,
+    "codex_jsonl_activity": cached_activity,
+    "generic_jsonl_activity": cached_activity,
+}
+
+FINAL_MESSAGE_SOURCE_TYPES = {"file", "structured_event", "stdout_tail", "not_available"}
+VALID_FINAL_MESSAGE_PARSER_IDS = {
+    "generic_stdout_last_message",
+    "generic_structured_event_message",
+}
+
+
+def validate_event_parser(parser_id: str) -> None:
+    if parser_id not in EVENT_PARSERS:
+        raise ValueError(f"Unknown agent event parser: {parser_id}")
+
+
+def validate_usage_parser(parser_id: str) -> None:
+    if parser_id not in USAGE_PARSERS:
+        raise ValueError(f"Unknown agent usage parser: {parser_id}")
+
+
+def validate_activity_parser(parser_id: str) -> None:
+    if parser_id not in ACTIVITY_PARSERS:
+        raise ValueError(f"Unknown agent activity parser: {parser_id}")
+
+
+def validate_final_message_config(source_type: str, parser_id: str | None = None) -> None:
+    if source_type not in FINAL_MESSAGE_SOURCE_TYPES:
+        raise ValueError(
+            f"Unknown final message source_type: {source_type}. "
+            f"Valid source types: {', '.join(sorted(FINAL_MESSAGE_SOURCE_TYPES))}"
+        )
+    if parser_id and parser_id not in VALID_FINAL_MESSAGE_PARSER_IDS:
+        raise ValueError(f"Unknown final message parser: {parser_id}")
+
+
+def normalize_event_with_parser(raw_line: str, parser_id: str) -> dict[str, Any] | None:
+    validate_event_parser(parser_id)
+    parser = EVENT_PARSERS[parser_id]
+    return parser(raw_line)
+
+
+def parse_usage_from_events(events_path: Path, usage_config: Any) -> dict[str, Any]:
+    parser_id = getattr(usage_config, "parser", None) or "generic_cli_usage"
+    validate_usage_parser(parser_id)
+    parser = USAGE_PARSERS[parser_id]
+    usage = parser(events_path)
+    usage.setdefault("parser_id", parser_id)
+    return usage
+
+
+def parse_activity_from_events(events_path: Path, activity_config: Any) -> dict[str, Any]:
+    parser_id = getattr(activity_config, "parser", None) or "generic_jsonl_activity"
+    validate_activity_parser(parser_id)
+    parser = ACTIVITY_PARSERS[parser_id]
+    activity = parser(events_path)
+    activity.setdefault("parser_id", parser_id)
+    return activity

--- a/assist_tools/skills_benchmark/skills/harness/agents/registry.py
+++ b/assist_tools/skills_benchmark/skills/harness/agents/registry.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent adapter registry for the benchmark harness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from .base import AgentAdapter
+from .config import ConfigurableAgentAdapter
+
+BENCHMARK_ROOT = Path(__file__).resolve().parents[3]
+AGENT_CONFIG_DIR = BENCHMARK_ROOT / "config" / "agents"
+DEFAULT_BENCHMARK_AGENT = "codex"
+
+
+@dataclass(frozen=True)
+class AgentRegistration:
+    name: str
+    category: str
+    config_name: str | None = None
+    message: str = ""
+
+
+AGENT_REGISTRY: dict[str, AgentRegistration] = {
+    "codex": AgentRegistration("codex", "supported", "codex.yaml"),
+    "claude": AgentRegistration("claude", "supported", "claude.yaml"),
+    "hermes": AgentRegistration("hermes", "known_pending", None, "Hermes benchmark adapter is planned."),
+    "openclaw": AgentRegistration("openclaw", "known_pending", None, "OpenClaw benchmark adapter is planned."),
+}
+
+
+def supported_agent_names() -> tuple[str, ...]:
+    return tuple(name for name, registration in AGENT_REGISTRY.items() if registration.category == "supported")
+
+
+def validate_benchmark_agent(agent: str) -> str:
+    registration = AGENT_REGISTRY.get(agent)
+    if registration is None:
+        supported = ", ".join(supported_agent_names())
+        known_pending = ", ".join(name for name, item in AGENT_REGISTRY.items() if item.category == "known_pending")
+        raise ValueError(
+            f"Unsupported BENCHMARK_AGENT={agent!r}. Supported benchmark agents: {supported}. "
+            f"Known pending agents: {known_pending}."
+        )
+    if registration.category == "known_pending":
+        raise ValueError(f"BENCHMARK_AGENT={agent!r} is known but not implemented. {registration.message}")
+    if registration.category != "supported":
+        raise ValueError(f"BENCHMARK_AGENT={agent!r} has invalid registry category {registration.category!r}")
+    return agent
+
+
+@lru_cache(maxsize=None)
+def get_agent_adapter(agent: str) -> AgentAdapter:
+    name = validate_benchmark_agent(agent)
+    registration = AGENT_REGISTRY[name]
+    if not registration.config_name:
+        raise ValueError(f"BENCHMARK_AGENT={name!r} is missing an agent config file")
+    return ConfigurableAgentAdapter(AGENT_CONFIG_DIR / registration.config_name)
+
+
+def load_agent_adapter(agent: str) -> AgentAdapter:
+    return get_agent_adapter(agent)
+
+
+def clear_agent_adapter_cache() -> None:
+    """Reset adapter instances cached from YAML configs.
+
+    Tests that patch registry entries or config files should call this before
+    reloading adapters.
+    """
+
+    get_agent_adapter.cache_clear()
+
+
+def normalize_agent_event(agent: str, raw_line: str) -> dict | None:
+    return get_agent_adapter(agent).normalize_event(raw_line)

--- a/assist_tools/skills_benchmark/skills/harness/common.py
+++ b/assist_tools/skills_benchmark/skills/harness/common.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common helpers used by harness command modules."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: str | Path, default: Any = None) -> Any:
+    try:
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def load_text(path: str | Path, default: str = "") -> str:
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return default
+
+
+def as_number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def write_json(path: str | Path, value: Any) -> None:
+    Path(path).write_text(json.dumps(value, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def make_tree_readable(path: str | Path) -> None:
+    """Best-effort fix for Docker-created result files on bind mounts."""
+    root = Path(path)
+    paths = [root]
+    if root.is_dir() and not root.is_symlink():
+        for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+            directory = Path(dirpath)
+            dirnames[:] = [name for name in dirnames if not (directory / name).is_symlink()]
+            paths.extend(directory / name for name in dirnames)
+            paths.extend(directory / name for name in filenames if not (directory / name).is_symlink())
+    for item in paths:
+        try:
+            if item.is_symlink():
+                continue
+            mode = item.stat().st_mode
+            if item.is_dir():
+                mode |= (
+                    stat.S_IRUSR
+                    | stat.S_IWUSR
+                    | stat.S_IXUSR
+                    | stat.S_IRGRP
+                    | stat.S_IXGRP
+                    | stat.S_IROTH
+                    | stat.S_IXOTH
+                )
+            else:
+                mode |= stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+            item.chmod(mode)
+        except OSError:
+            continue
+
+
+def bool_from_text(value: str) -> bool:
+    return str(value).lower() == "true"
+
+
+def flatten_numbers(obj: Any, prefix: str = "") -> dict[str, float]:
+    flattened: dict[str, float] = {}
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if key == "all_metrics":
+                continue
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            flattened.update(flatten_numbers(value, child_prefix))
+    elif isinstance(obj, list):
+        for index, value in enumerate(obj):
+            child_prefix = f"{prefix}.{index}" if prefix else str(index)
+            flattened.update(flatten_numbers(value, child_prefix))
+    elif isinstance(obj, bool):
+        flattened[prefix] = 1 if obj else 0
+    elif isinstance(obj, (int, float)):
+        flattened[prefix] = obj
+    return flattened

--- a/assist_tools/skills_benchmark/skills/harness/container/__init__.py
+++ b/assist_tools/skills_benchmark/skills/harness/container/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/assist_tools/skills_benchmark/skills/harness/container/sdk_skills_setup.py
+++ b/assist_tools/skills_benchmark/skills/harness/container/sdk_skills_setup.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Apply configured SDK skills setup inside the benchmark image."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+SDK_SKILLS_SOURCE = Path("/tmp/sdk_skills")
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+def agent_home() -> Path:
+    return Path(env("BENCHMARK_AGENT_HOME", "/workspace/agent-home"))
+
+
+def skills_target() -> Path:
+    return agent_home() / "skills"
+
+
+def run_command(command: str, output_path: Path) -> None:
+    if not command:
+        raise SystemExit("skills.setup.type=command requires SKILLS_INSTALL_COMMAND")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as stream:
+        subprocess.run(["/bin/bash", "-c", command], check=True, stdout=stream)
+
+
+def visible_files(path: Path) -> list[str]:
+    if not path.is_dir():
+        return []
+    files: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(path, followlinks=False):
+        directory = Path(dirpath)
+        dirnames[:] = [name for name in dirnames if not (directory / name).is_symlink()]
+        for name in filenames:
+            item = directory / name
+            if item.is_symlink() or not item.is_file():
+                continue
+            files.append(str(item.relative_to(path)))
+    return sorted(files)
+
+
+def copy_skills_folder() -> dict:
+    target = skills_target()
+    if not SDK_SKILLS_SOURCE.is_dir():
+        raise SystemExit(f"Staged SDK skills folder is missing: {SDK_SKILLS_SOURCE}")
+    target.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(SDK_SKILLS_SOURCE, target, dirs_exist_ok=True)
+    files = visible_files(target)
+    return {
+        "status": "success",
+        "agent": env("BENCHMARK_DOCKER_AGENT", "unknown"),
+        "mechanism": "copy",
+        "source": str(SDK_SKILLS_SOURCE),
+        "target": str(target),
+        "file_count": len(files),
+    }
+
+
+def write_generic_list(output_path: Path, *, reason: str | None = None) -> None:
+    target = skills_target()
+    payload = {
+        "status": "success" if reason is None else "skipped",
+        "agent": env("BENCHMARK_DOCKER_AGENT", "unknown"),
+        "mechanism": env("SKILLS_SETUP_TYPE", "none"),
+        "target": str(target),
+        "installed": visible_files(target),
+    }
+    if reason:
+        payload["reason"] = reason
+    write_json(output_path, payload)
+
+
+def write_setup_metadata(home: Path) -> None:
+    payload = {
+        "agent": env("BENCHMARK_DOCKER_AGENT", "unknown"),
+        "command": env("SKILLS_INSTALL_COMMAND"),
+        "expected_source": env("SKILLS_INSTALL_EXPECTED_SOURCE"),
+        "network_isolation_enforced": False,
+        "setup_type": env("SKILLS_SETUP_TYPE", "none"),
+        "skills_source": str(SDK_SKILLS_SOURCE),
+        "target": str(skills_target()),
+    }
+    write_json(home / "sdk_skills_build_metadata.json", payload)
+
+
+def main() -> int:
+    home = agent_home()
+    home.mkdir(parents=True, exist_ok=True)
+    install_output = home / env("SKILLS_INSTALL_OUTPUT", "skills_build_install.json")
+    list_output = home / env("SKILLS_LIST_OUTPUT", "skills_list.json")
+    setup_type = env("SKILLS_SETUP_TYPE", "none")
+    write_setup_metadata(home)
+
+    if setup_type == "command":
+        run_command(env("SKILLS_INSTALL_COMMAND"), install_output)
+        list_command = env("SKILLS_LIST_COMMAND")
+        if list_command:
+            run_command(list_command, list_output)
+        else:
+            write_generic_list(list_output, reason="SKILLS_LIST_COMMAND is empty")
+    elif setup_type == "copy":
+        write_json(install_output, copy_skills_folder())
+        list_command = env("SKILLS_LIST_COMMAND")
+        if list_command:
+            run_command(list_command, list_output)
+        else:
+            write_generic_list(list_output)
+    elif setup_type == "none":
+        write_json(
+            install_output,
+            {
+                "status": "skipped",
+                "agent": env("BENCHMARK_DOCKER_AGENT", "unknown"),
+                "mechanism": "none",
+                "reason": "SDK profile skills.setup.type is none",
+            },
+        )
+        write_generic_list(list_output, reason="SDK profile skills.setup.type is none")
+    else:
+        raise SystemExit(f"Unsupported SKILLS_SETUP_TYPE={setup_type!r}")
+
+    print(list_output.read_text(encoding="utf-8"), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/assist_tools/skills_benchmark/skills/harness/host/__init__.py
+++ b/assist_tools/skills_benchmark/skills/harness/host/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/assist_tools/skills_benchmark/skills/harness/host/build.py
+++ b/assist_tools/skills_benchmark/skills/harness/host/build.py
@@ -1,0 +1,555 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host-side Docker image build orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..agents.base import AgentAdapter
+from ..agents.config import ConfigurableAgentAdapter
+from ..agents.registry import DEFAULT_BENCHMARK_AGENT, load_agent_adapter
+from ..sdks.base import SdkAdapter, SdkSkillsSetup, SdkSource, SdkWheelBuild, SdkWheelVariant
+from ..sdks.config import ConfigurableSdkAdapter
+from ..sdks.registry import DEFAULT_BENCHMARK_SDK, load_sdk_adapter
+from .common import SCRIPT_DIR, emit
+
+REPO_ROOT = SCRIPT_DIR.parents[1]
+DEFAULT_UV_IMAGE = "ghcr.io/astral-sh/uv:0.11.19"
+DEFAULT_NODE_IMAGE = "node:22.16.0-bookworm-slim"
+
+
+@dataclass(frozen=True)
+class PreparedSdkWheel:
+    wheel: Path
+    source_type: str
+    source_path: Path
+
+
+def looks_like_profile_path(value: str) -> bool:
+    candidate = Path(value).expanduser()
+    return candidate.is_absolute() or len(candidate.parts) > 1 or candidate.suffix in {".yaml", ".yml"}
+
+
+def load_sdk_profile(profile: str) -> SdkAdapter:
+    candidate = Path(profile).expanduser()
+    if candidate.is_file():
+        return ConfigurableSdkAdapter(candidate.resolve())
+    if looks_like_profile_path(profile):
+        raise SystemExit(f"SDK profile file does not exist: {candidate}")
+    try:
+        return load_sdk_adapter(profile)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
+def load_agent_profile(profile: str) -> AgentAdapter:
+    candidate = Path(profile).expanduser()
+    if candidate.is_file():
+        return ConfigurableAgentAdapter(candidate.resolve())
+    if looks_like_profile_path(profile):
+        raise SystemExit(f"Agent profile file does not exist: {candidate}")
+    try:
+        return load_agent_adapter(profile)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
+def canonical_dir(path: Path, label: str) -> Path:
+    expanded = path.expanduser()
+    if not expanded.is_dir():
+        raise SystemExit(f"{label} directory does not exist: {expanded}")
+    return expanded.resolve()
+
+
+def assert_sdk_repo_not_in_harness_source(path: Path) -> None:
+    try:
+        path.relative_to(SCRIPT_DIR)
+    except ValueError:
+        return
+    raise SystemExit(
+        "SDK profile source.path must not be inside assist_tools/skills_benchmark. "
+        "Only built wheel artifacts are staged into the Docker build context."
+    )
+
+
+def repo_has_markers(path: Path, markers: tuple[str, ...]) -> bool:
+    for marker in markers:
+        marker_path = path / marker.rstrip("/")
+        if marker.endswith("/"):
+            if not marker_path.is_dir():
+                return False
+        elif not marker_path.exists():
+            return False
+    return True
+
+
+def resolve_sdk_source(sdk: SdkAdapter) -> SdkSource:
+    source = sdk.source(repo_root=REPO_ROOT, home=Path.home())
+    if source.source_type == "repo":
+        if source.repo_path is None:
+            raise SystemExit(f"{sdk.display_name} SDK profile source.type=repo requires source.path")
+        repo = canonical_dir(source.repo_path, "SDK profile source.path")
+        if not repo_has_markers(repo, source.repo_markers):
+            markers = ", ".join(source.repo_markers)
+            raise SystemExit(
+                f"SDK profile source.path does not look like a {sdk.display_name} checkout: {repo}. "
+                f"Expected marker(s): {markers}."
+            )
+        assert_sdk_repo_not_in_harness_source(repo)
+        return SdkSource(source_type="repo", repo_path=repo, repo_markers=source.repo_markers)
+
+    if source.source_type == "wheels":
+        raw_wheels = source.wheel_paths or {}
+        wheel_paths = {}
+        for variant_name in ("skills", "baseline"):
+            wheel = raw_wheels.get(variant_name)
+            if wheel is None:
+                raise SystemExit(f"{sdk.display_name} SDK profile source.wheels.{variant_name} is required")
+            expanded = wheel.expanduser()
+            if not expanded.is_file():
+                raise SystemExit(f"SDK profile source.wheels.{variant_name} file does not exist: {expanded}")
+            if expanded.suffix != ".whl":
+                raise SystemExit(f"SDK profile source.wheels.{variant_name} must be a .whl file: {expanded}")
+            wheel_paths[variant_name] = expanded.resolve()
+        return SdkSource(source_type="wheels", wheel_paths=wheel_paths)
+
+    raise SystemExit(f"Unsupported SDK profile source.type={source.source_type!r}")
+
+
+def latest_sdk_wheel(search_dir: Path, include_globs: tuple[str, ...], exclude_globs: tuple[str, ...]) -> Path | None:
+    wheels: dict[Path, None] = {}
+    for pattern in include_globs:
+        for wheel in search_dir.glob(pattern):
+            if wheel.suffix == ".whl":
+                wheels[wheel] = None
+    matches: list[tuple[Path, float]] = []
+    for wheel in wheels:
+        if any(fnmatch.fnmatch(wheel.name, pattern) for pattern in exclude_globs):
+            continue
+        try:
+            matches.append((wheel, wheel.stat().st_mtime))
+        except OSError:
+            continue
+    if not matches:
+        return None
+    return max(matches, key=lambda item: item[1])[0]
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def git_commit(repo: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    commit = result.stdout.strip()
+    return commit or None
+
+
+def clean_wheels(out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for wheel in out_dir.glob("*.whl"):
+        wheel.unlink()
+
+
+def clean_directory(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True)
+
+
+def copy_directory_contents(src: Path, dst: Path) -> None:
+    def ignore(_dir: str, names: list[str]) -> set[str]:
+        return {name for name in names if name == "__pycache__" or name.endswith(".pyc")}
+
+    for child in src.iterdir():
+        target = dst / child.name
+        if child.is_dir():
+            shutil.copytree(child, target, ignore=ignore)
+        else:
+            shutil.copy2(child, target)
+
+
+def resolve_sdk_skills_setup(sdk: SdkAdapter) -> SdkSkillsSetup:
+    setup = sdk.skills_setup(repo_root=REPO_ROOT, home=Path.home())
+    if setup.setup_type == "copy":
+        if setup.source_path is None:
+            raise SystemExit(f"{sdk.display_name} SDK profile skills.setup.source_path is required")
+        source_path = canonical_dir(setup.source_path, "SDK profile skills.setup.source_path")
+        return SdkSkillsSetup(
+            setup_type=setup.setup_type,
+            source_path=source_path,
+            install_command=setup.install_command,
+            list_command=setup.list_command,
+            install_output=setup.install_output,
+            list_output=setup.list_output,
+            expected_source=setup.expected_source,
+        )
+    return setup
+
+
+def stage_sdk_skills_setup(context: Path, setup: SdkSkillsSetup) -> None:
+    target = context / "sdk_skills"
+    clean_directory(target)
+    if setup.setup_type != "copy":
+        return
+    if setup.source_path is None:
+        raise SystemExit("SDK profile skills.setup.source_path is required for copy setup")
+    copy_directory_contents(setup.source_path, target)
+    emit(f"Using SDK skills folder: {setup.source_path}")
+
+
+def stage_configured_wheel(
+    *,
+    wheel: Path,
+    sdk: SdkAdapter,
+    variant: SdkWheelVariant,
+    out_dir: Path,
+) -> PreparedSdkWheel:
+    if not any(fnmatch.fnmatch(wheel.name, pattern) for pattern in variant.wheel_globs):
+        raise SystemExit(
+            f"Configured {sdk.package_name} {variant.label} wheel {wheel.name!r} does not match "
+            f"expected pattern(s): {variant.wheel_globs}."
+        )
+    if any(fnmatch.fnmatch(wheel.name, pattern) for pattern in variant.wheel_exclude_globs):
+        raise SystemExit(
+            f"Configured {sdk.package_name} {variant.label} wheel {wheel.name!r} matches excluded "
+            f"pattern(s): {variant.wheel_exclude_globs}."
+        )
+    clean_wheels(out_dir)
+    target = out_dir / wheel.name
+    shutil.copy2(wheel, target)
+    emit(f"Using configured {variant.label} wheel: {wheel}")
+    return PreparedSdkWheel(wheel=target, source_type="wheels", source_path=wheel)
+
+
+def build_sdk_wheel_from_repo(
+    *,
+    repo: Path,
+    sdk: SdkAdapter,
+    variant: SdkWheelVariant,
+    out_dir: Path,
+) -> PreparedSdkWheel:
+    clean_wheels(out_dir)
+    uv = shutil.which("uv")
+    if uv is None:
+        raise SystemExit(
+            "Host uv is required to build SDK wheels. "
+            "To use existing wheels, set source.type: wheels and build.type: provided_wheels in the SDK profile."
+        )
+
+    emit(f"=== Building {sdk.package_name} {variant.label} wheel ===")
+    env = {**os.environ}
+    if sdk.build_env_name:
+        env[sdk.build_env_name] = variant.build_env_value
+    status = subprocess.call([uv, "build", "--wheel", "--out-dir", str(out_dir)], cwd=repo, env=env)
+    if status != 0:
+        raise SystemExit(status)
+
+    wheel = latest_sdk_wheel(out_dir, variant.wheel_globs, variant.wheel_exclude_globs)
+    if wheel is None:
+        raise SystemExit(
+            f"No {sdk.package_name} {variant.label} wheel found under {out_dir}. "
+            f"Expected a wheel matching {variant.wheel_globs} excluding {variant.wheel_exclude_globs}."
+        )
+    return PreparedSdkWheel(wheel=wheel, source_type="repo", source_path=repo)
+
+
+def prepare_sdk_wheel(
+    *,
+    source: SdkSource,
+    wheel_build: SdkWheelBuild,
+    sdk: SdkAdapter,
+    variant: SdkWheelVariant,
+    out_dir: Path,
+) -> PreparedSdkWheel:
+    if wheel_build.build_type == "uv_wheel":
+        if source.repo_path is None:
+            raise SystemExit(f"{sdk.display_name} SDK profile build.type=uv_wheel requires source.type=repo")
+        return build_sdk_wheel_from_repo(repo=source.repo_path, sdk=sdk, variant=variant, out_dir=out_dir)
+    if wheel_build.build_type == "provided_wheels":
+        wheel_paths = source.wheel_paths or {}
+        wheel = wheel_paths.get(variant.name)
+        if wheel is None:
+            raise SystemExit(f"{sdk.display_name} SDK profile build.type=provided_wheels requires source.wheels")
+        return stage_configured_wheel(wheel=wheel, sdk=sdk, variant=variant, out_dir=out_dir)
+    raise SystemExit(f"Unsupported SDK profile build.type={wheel_build.build_type!r}")
+
+
+def write_wheel_metadata(
+    *,
+    sdk: SdkAdapter,
+    variant: SdkWheelVariant,
+    wheel_build: SdkWheelBuild,
+    prepared: PreparedSdkWheel,
+    out_dir: Path,
+) -> None:
+    payload = {
+        "build_env": {"name": sdk.build_env_name, "value": variant.build_env_value} if sdk.build_env_name else None,
+        "build_type": wheel_build.build_type,
+        "filename": prepared.wheel.name,
+        "git_commit": git_commit(prepared.source_path) if prepared.source_type == "repo" else None,
+        "import_name": sdk.import_name,
+        "package_name": sdk.package_name,
+        "sdk": sdk.metadata(),
+        "sdk_name": sdk.name,
+        "sha256": file_sha256(prepared.wheel),
+        "source_path": str(prepared.source_path),
+        "source_type": prepared.source_type,
+        "variant": variant.name,
+    }
+    metadata = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    (out_dir / "sdk_wheel_metadata.json").write_text(metadata, encoding="utf-8")
+
+
+def copy_harness(src: Path, dst: Path) -> None:
+    def ignore(_dir: str, names: list[str]) -> set[str]:
+        return {name for name in names if name == "__pycache__" or name.endswith(".pyc")}
+
+    shutil.copytree(src, dst, ignore=ignore)
+
+
+def copy_harness_package(context: Path) -> None:
+    package_root = context / "assist_tools" / "skills_benchmark" / "skills"
+    package_root.mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / "assist_tools" / "__init__.py", context / "assist_tools" / "__init__.py")
+    shutil.copy2(SCRIPT_DIR / "__init__.py", context / "assist_tools" / "skills_benchmark" / "__init__.py")
+    copy_harness(SCRIPT_DIR / "config", context / "assist_tools" / "skills_benchmark" / "config")
+    shutil.copy2(SCRIPT_DIR / "skills" / "__init__.py", package_root / "__init__.py")
+    copy_harness(SCRIPT_DIR / "skills" / "harness", package_root / "harness")
+
+
+def prepare_build_context() -> Path:
+    context = Path(tempfile.mkdtemp(prefix="skills-benchmark-build-context.", dir=os.environ.get("TMPDIR") or None))
+    try:
+        (context / "dist" / "skills").mkdir(parents=True)
+        (context / "dist" / "baseline").mkdir(parents=True)
+        (context / "sdk_skills").mkdir(parents=True)
+        shutil.copy2(SCRIPT_DIR / "docker" / "Dockerfile", context / "Dockerfile")
+        copy_harness_package(context)
+        shutil.copy2(SCRIPT_DIR / "docker" / "build_context.dockerignore", context / ".dockerignore")
+    except BaseException:
+        shutil.rmtree(context, ignore_errors=True)
+        raise
+    return context
+
+
+def docker_build(
+    *,
+    image: str,
+    target: str,
+    context: Path,
+    uv_image: str,
+    node_image: str,
+    sdk_build_args: dict[str, str],
+    agent_build_args: dict[str, str],
+    no_cache: bool,
+) -> None:
+    cache_args = ["--no-cache"] if no_cache else []
+    rendered_sdk_build_args = render_docker_build_args(sdk_build_args, allow_value_equals=True)
+    rendered_agent_build_args = render_agent_build_args(agent_build_args)
+    status = subprocess.call(
+        [
+            "docker",
+            "build",
+            *cache_args,
+            "--target",
+            target,
+            "--build-arg",
+            f"UV_IMAGE={uv_image}",
+            "--build-arg",
+            f"NODE_IMAGE={node_image}",
+            *rendered_sdk_build_args,
+            *rendered_agent_build_args,
+            "-t",
+            image,
+            str(context),
+        ]
+    )
+    if status != 0:
+        raise SystemExit(status)
+
+
+def render_docker_build_args(build_args: dict[str, str], *, allow_value_equals: bool = False) -> list[str]:
+    rendered_build_args = []
+    for key, value in sorted(build_args.items()):
+        if "=" in str(key):
+            raise ValueError(f"Docker build arg key must not contain '=': {key}")
+        if "=" in str(value) and not allow_value_equals:
+            raise ValueError(f"Docker build arg {key} value must not contain '='")
+        rendered_build_args.extend(["--build-arg", f"{key}={value}"])
+    return rendered_build_args
+
+
+def render_agent_build_args(agent_build_args: dict[str, str]) -> list[str]:
+    return render_docker_build_args(agent_build_args)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Build agent skills benchmark Docker images.")
+    parser.add_argument(
+        "--sdk-profile",
+        default=DEFAULT_BENCHMARK_SDK,
+        help=f"SDK profile name or YAML path. Defaults to {DEFAULT_BENCHMARK_SDK}.",
+    )
+    parser.add_argument(
+        "--agent-profile",
+        default=DEFAULT_BENCHMARK_AGENT,
+        help=f"Agent profile name or YAML path. Defaults to {DEFAULT_BENCHMARK_AGENT}.",
+    )
+    parser.add_argument("--skip-skills-image", action="store_true", help="Do not build the skills image.")
+    parser.add_argument("--skip-baseline-image", action="store_true", help="Do not build the baseline image.")
+    parser.add_argument("--no-cache", action="store_true", help="Pass --no-cache to docker build.")
+    parser.add_argument("--uv-image", default=DEFAULT_UV_IMAGE, help="uv image used as the Docker uv source stage.")
+    parser.add_argument("--node-image", default=DEFAULT_NODE_IMAGE, help="Node runtime image used as the Docker base.")
+    args = parser.parse_args(argv)
+
+    try:
+        adapter = load_agent_profile(args.agent_profile)
+        sdk = load_sdk_profile(args.sdk_profile)
+        wheel_build = sdk.wheel_build()
+        skills_variant = sdk.wheel_variant("skills")
+        baseline_variant = sdk.wheel_variant("baseline")
+        skills_setup = resolve_sdk_skills_setup(sdk)
+        targets = adapter.image_targets()
+        sdk_build_args = sdk.docker_build_args()
+        agent_build_args = adapter.build_args()
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    image_name = targets.skills
+    baseline_image_name = targets.baseline
+    report_image_name = targets.report
+    build_skills_image = not args.skip_skills_image
+    build_baseline_image = not args.skip_baseline_image
+
+    context = None
+    try:
+        emit("=== Preparing minimal Docker build context ===")
+        context = prepare_build_context()
+        emit(f"Agent profile: {args.agent_profile} -> {adapter.display_name} ({adapter.name})")
+        emit(f"SDK profile: {args.sdk_profile} -> {sdk.display_name} ({sdk.package_name})")
+        emit(f"SDK wheel build: {wheel_build.build_type}")
+        if build_skills_image:
+            emit(f"SDK skills setup: {skills_setup.setup_type}")
+            stage_sdk_skills_setup(context, skills_setup)
+        if build_skills_image or build_baseline_image:
+            source = resolve_sdk_source(sdk)
+            if source.source_type == "repo":
+                emit(f"Using SDK repo: {source.repo_path}")
+            else:
+                emit("Using SDK wheels from profile.")
+
+            if build_skills_image:
+                skills_prepared = prepare_sdk_wheel(
+                    source=source,
+                    wheel_build=wheel_build,
+                    sdk=sdk,
+                    variant=skills_variant,
+                    out_dir=context / "dist" / "skills",
+                )
+                emit(f"Using skills wheel: {skills_prepared.wheel.name}")
+                write_wheel_metadata(
+                    sdk=sdk,
+                    variant=skills_variant,
+                    wheel_build=wheel_build,
+                    prepared=skills_prepared,
+                    out_dir=context / "dist" / "skills",
+                )
+
+            if build_baseline_image:
+                baseline_prepared = prepare_sdk_wheel(
+                    source=source,
+                    wheel_build=wheel_build,
+                    sdk=sdk,
+                    variant=baseline_variant,
+                    out_dir=context / "dist" / "baseline",
+                )
+                emit(f"Using baseline wheel: {baseline_prepared.wheel.name}")
+                write_wheel_metadata(
+                    sdk=sdk,
+                    variant=baseline_variant,
+                    wheel_build=wheel_build,
+                    prepared=baseline_prepared,
+                    out_dir=context / "dist" / "baseline",
+                )
+
+        emit(f"Docker build context: {context}")
+        emit(f"UV image: {args.uv_image}")
+        emit(f"Node runtime image: {args.node_image}")
+        for key, value in sorted(sdk_build_args.items()):
+            emit(f"SDK build arg: {key}={value}")
+        for key, value in sorted(agent_build_args.items()):
+            emit(f"Agent build arg: {key}={value}")
+        emit(f"Docker build no-cache: {str(args.no_cache).lower()}")
+        if build_skills_image:
+            emit(f"=== Building Docker skills image: {image_name} ===")
+            docker_build(
+                image=image_name,
+                target="skills",
+                context=context,
+                uv_image=args.uv_image,
+                node_image=args.node_image,
+                sdk_build_args=sdk_build_args,
+                agent_build_args=agent_build_args,
+                no_cache=args.no_cache,
+            )
+        if build_baseline_image:
+            emit(f"=== Building Docker baseline image: {baseline_image_name} ===")
+            docker_build(
+                image=baseline_image_name,
+                target="baseline",
+                context=context,
+                uv_image=args.uv_image,
+                node_image=args.node_image,
+                sdk_build_args=sdk_build_args,
+                agent_build_args=agent_build_args,
+                no_cache=args.no_cache,
+            )
+
+        emit(f"Skills image: {image_name}")
+        emit(f"Baseline image: {baseline_image_name}")
+        emit(f"Report image: {report_image_name}")
+        return 0
+    finally:
+        if context is not None:
+            shutil.rmtree(context, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/assist_tools/skills_benchmark/skills/harness/host/common.py
+++ b/assist_tools/skills_benchmark/skills/harness/host/common.py
@@ -1,0 +1,636 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared host-side Docker benchmark helpers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+from ..agents.base import AgentAdapter, DockerMount
+from ..agents.registry import DEFAULT_BENCHMARK_AGENT, load_agent_adapter, validate_benchmark_agent
+from ..common import write_json
+
+SCRIPT_DIR = Path(__file__).resolve().parents[3]
+PROMPT_FILE_NAME = "benchmark_prompt.txt"
+CONTAINER_PROMPT_DIR = "/workspace/prompts"
+CONTAINER_PROMPT_PATH = f"{CONTAINER_PROMPT_DIR}/{PROMPT_FILE_NAME}"
+OUTPUT_LOCK = threading.Lock()
+__all__ = [
+    "SCRIPT_DIR",
+    "PROMPT_FILE_NAME",
+    "CONTAINER_PROMPT_DIR",
+    "CONTAINER_PROMPT_PATH",
+    "OUTPUT_LOCK",
+    "HostCliOptions",
+    "ImageConfig",
+    "CaseConfig",
+    "absolute_path",
+    "add_agent_auth_mounts",
+    "add_agent_passthrough_env",
+    "benchmark_agent_adapter_from_env",
+    "benchmark_agent_from_env",
+    "case_config",
+    "command_stdout_to_file",
+    "default_results_root",
+    "docker_args_for_case",
+    "docker_env",
+    "emit",
+    "env_bool",
+    "expand_home_path",
+    "optional_int_env",
+    "parse_host_cli_options",
+    "print_usage",
+    "stream_command",
+    "timestamp_slug",
+    "write_runtime_image",
+]
+
+
+def timestamp_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
+
+
+def expand_home_path(value: str) -> str:
+    return str(Path(value).expanduser())
+
+
+def absolute_path(value: str) -> Path:
+    expanded = Path(expand_home_path(value))
+    return expanded if expanded.is_absolute() else Path.cwd() / expanded
+
+
+def env_bool(name: str, default: str) -> bool:
+    value = os.environ.get(name, default)
+    if value not in {"true", "false"}:
+        raise SystemExit(f"{name} must be true or false; got {value}")
+    return value == "true"
+
+
+def default_results_root() -> Path:
+    return Path(
+        os.environ.get(
+            "AGENT_BENCHMARK_RESULTS_ROOT",
+            os.environ.get("CODEX_DOCKER_RESULTS_ROOT", str(SCRIPT_DIR / "results")),
+        )
+    )
+
+
+def print_usage(command: str) -> None:
+    usage = {
+        "run-one": "Run one agent benchmark case against an arbitrary job folder.",
+        "pair": "Run paired skills/no-skills benchmark cases against a job folder.",
+        "interactive": "Start an interactive benchmark container with a job folder mounted.",
+    }.get(command, "Run an agent benchmark command against a job folder.")
+    print(
+        f"Usage: {Path(sys.argv[0]).name} --prompt PATH [--training-code PATH] [--results-root PATH] [PATH]\n\n"
+        f"{usage}\n\n"
+        "Arguments:\n"
+        "  PATH                    Job folder. Equivalent to --training-code.\n\n"
+        "Options:\n"
+        "  --prompt PATH           Prompt file to mount as the measured agent input.\n"
+        "  --training-code PATH    Job folder to mount into the benchmark container.\n"
+        "  --agent NAME            Agent profile to run. Defaults to codex.\n"
+        "  --model NAME            Agent model to run. Required by agents without a default.\n"
+        "  --mode NAME             run-one mode: with_skills or without_skills.\n"
+        "  --workflow NAME         Workflow label for pair/run-one records. Defaults to default.\n"
+        "  --job-scale NAME        Job size policy for pair/run-one. small, medium, or large.\n"
+        "  --agent-home PATH       Host auth/config directory for the selected agent.\n"
+        "  --no-agent-auth-mount   Do not mount host agent auth/config files.\n"
+        "  --results-root PATH     Parent directory for generated timestamped result directories.\n"
+        "  --output-dir PATH       Exact result directory for this run or comparison.\n"
+        "  --result-root PATH      Exact result directory for pair comparisons.\n"
+        "  --result-dir PATH       Exact result directory for run-one.\n"
+        "  -h, --help              Show this help."
+    )
+
+
+@dataclass(frozen=True)
+class HostCliOptions:
+    job_input: Path
+    prompt_path: Path
+    results_root: Path | None = None
+    result_root: Path | None = None
+    result_dir: Path | None = None
+    agent: str | None = None
+    model: str | None = None
+    mode: str | None = None
+    workflow: str | None = None
+    job_scale: str | None = None
+    agent_home: Path | None = None
+    mount_agent_auth: bool | None = None
+
+
+def _option_value(argv: list[str], index: int, option: str) -> tuple[str, int]:
+    arg = argv[index]
+    if arg.startswith(f"{option}="):
+        return arg.split("=", 1)[1], index + 1
+    if index + 1 >= len(argv):
+        raise SystemExit(f"{option} requires a path")
+    return argv[index + 1], index + 2
+
+
+def parse_host_cli_options(argv: list[str], command: str) -> HostCliOptions:
+    job_input = os.environ.get("JOB_INPUT_DIR") or os.environ.get("TRAINING_CODE") or ""
+    prompt_input = ""
+    set_by_arg = False
+    results_root: Path | None = None
+    result_root: Path | None = None
+    result_dir: Path | None = None
+    agent: str | None = None
+    model: str | None = None
+    mode: str | None = None
+    workflow: str | None = None
+    job_scale: str | None = None
+    agent_home: Path | None = None
+    mount_agent_auth: bool | None = None
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--training-code" or arg.startswith("--training-code="):
+            value, index = _option_value(argv, index, "--training-code")
+            if set_by_arg:
+                raise SystemExit("Expected only one job folder")
+            job_input = value
+            set_by_arg = True
+        elif arg == "--prompt" or arg.startswith("--prompt="):
+            value, index = _option_value(argv, index, "--prompt")
+            if prompt_input:
+                raise SystemExit("Expected only one --prompt")
+            prompt_input = value
+        elif arg == "--agent" or arg.startswith("--agent="):
+            value, index = _option_value(argv, index, "--agent")
+            if agent is not None:
+                raise SystemExit("Expected only one --agent")
+            agent = value
+        elif arg == "--model" or arg.startswith("--model="):
+            value, index = _option_value(argv, index, "--model")
+            if model is not None:
+                raise SystemExit("Expected only one --model")
+            model = value
+        elif arg == "--mode" or arg.startswith("--mode="):
+            value, index = _option_value(argv, index, "--mode")
+            if command != "run-one":
+                raise SystemExit("--mode is only supported for run-one; use pair or scenario for comparisons.")
+            if mode is not None:
+                raise SystemExit("Expected only one --mode")
+            mode = value
+        elif arg == "--workflow" or arg.startswith("--workflow="):
+            value, index = _option_value(argv, index, "--workflow")
+            if workflow is not None:
+                raise SystemExit("Expected only one --workflow")
+            workflow = value
+        elif arg == "--job-scale" or arg.startswith("--job-scale="):
+            value, index = _option_value(argv, index, "--job-scale")
+            if job_scale is not None:
+                raise SystemExit("Expected only one --job-scale")
+            job_scale = value
+        elif arg == "--agent-home" or arg.startswith("--agent-home="):
+            value, index = _option_value(argv, index, "--agent-home")
+            if agent_home is not None:
+                raise SystemExit("Expected only one --agent-home")
+            agent_home = absolute_path(value)
+        elif arg == "--no-agent-auth-mount":
+            if mount_agent_auth is False:
+                raise SystemExit("Expected only one --no-agent-auth-mount")
+            mount_agent_auth = False
+            index += 1
+        elif arg == "--results-root" or arg.startswith("--results-root="):
+            value, index = _option_value(argv, index, "--results-root")
+            if results_root is not None:
+                raise SystemExit("Expected only one --results-root")
+            results_root = absolute_path(value)
+        elif arg == "--result-root" or arg.startswith("--result-root="):
+            value, index = _option_value(argv, index, "--result-root")
+            if result_root is not None:
+                raise SystemExit("Expected only one --result-root")
+            result_root = absolute_path(value)
+        elif arg == "--result-dir" or arg.startswith("--result-dir="):
+            value, index = _option_value(argv, index, "--result-dir")
+            if result_dir is not None:
+                raise SystemExit("Expected only one --result-dir")
+            result_dir = absolute_path(value)
+        elif arg == "--output-dir" or arg.startswith("--output-dir="):
+            value, index = _option_value(argv, index, "--output-dir")
+            if command == "run-one":
+                if result_dir is not None:
+                    raise SystemExit("Expected only one exact output directory")
+                result_dir = absolute_path(value)
+            elif command == "pair":
+                if result_root is not None:
+                    raise SystemExit("Expected only one exact output directory")
+                result_root = absolute_path(value)
+            else:
+                raise SystemExit(f"--output-dir is not supported for {command}")
+        elif arg in {"-h", "--help"}:
+            print_usage(command)
+            raise SystemExit(0)
+        elif arg == "--":
+            rest = argv[index + 1 :]
+            if len(rest) > 1:
+                raise SystemExit("Expected at most one job folder after --")
+            if rest:
+                if set_by_arg:
+                    raise SystemExit("Expected only one job folder")
+                job_input = rest[0]
+            break
+        elif arg.startswith("-"):
+            print_usage(command)
+            raise SystemExit(f"Unknown option: {arg}")
+        else:
+            if set_by_arg:
+                raise SystemExit("Expected only one job folder")
+            job_input = arg
+            set_by_arg = True
+            index += 1
+
+    if not job_input:
+        print_usage(command)
+        raise SystemExit("Job input folder is required. Pass PATH or --training-code PATH.")
+    if not prompt_input:
+        print_usage(command)
+        raise SystemExit("Prompt file is required. Pass --prompt PATH.")
+    for name, value in (
+        ("--agent", agent),
+        ("--model", model),
+        ("--mode", mode),
+        ("--workflow", workflow),
+        ("--job-scale", job_scale),
+    ):
+        if value is not None and not value.strip():
+            raise SystemExit(f"{name} requires a non-empty value")
+    path = absolute_path(job_input)
+    if not path.is_dir():
+        raise SystemExit(f"Job input must be an existing folder: {path}")
+    prompt_path = absolute_path(prompt_input)
+    if not prompt_path.is_file():
+        raise SystemExit(f"Prompt file must be an existing file: {prompt_path}")
+    if results_root is not None and (result_root is not None or result_dir is not None):
+        raise SystemExit("Use --results-root or an exact output option, not both.")
+    if command == "run-one" and result_root is not None:
+        raise SystemExit("--result-root is only supported for pair; use --result-dir for run-one.")
+    if command == "pair" and result_dir is not None:
+        raise SystemExit("--result-dir is only supported for run-one; use --result-root for comparisons.")
+    if command == "interactive" and (results_root is not None or result_root is not None or result_dir is not None):
+        raise SystemExit("Output directory options are not supported for interactive containers.")
+    return HostCliOptions(
+        job_input=path,
+        prompt_path=prompt_path,
+        results_root=results_root,
+        result_root=result_root,
+        result_dir=result_dir,
+        agent=agent,
+        model=model,
+        mode=mode,
+        workflow=workflow,
+        job_scale=job_scale,
+        agent_home=agent_home,
+        mount_agent_auth=mount_agent_auth,
+    )
+
+
+def emit(message: str = "", *, logs: Iterable[Path] = (), prefix: str | None = None, stderr: bool = False) -> None:
+    line = f"[{prefix}] {message}" if prefix else message
+    stream = sys.stderr if stderr else sys.stdout
+    with OUTPUT_LOCK:
+        print(line, file=stream, flush=True)
+        for log in logs:
+            log.parent.mkdir(parents=True, exist_ok=True)
+            with log.open("a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+
+
+def stream_command(
+    command: list[str],
+    *,
+    logs: Iterable[Path] = (),
+    prefix: str | None = None,
+    env: dict[str, str] | None = None,
+    timeout_seconds: int | None = None,
+) -> int:
+    try:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+        )
+    except OSError as exc:
+        program = command[0] if command else "<empty command>"
+        emit(f"Failed to start command {program}: {type(exc).__name__}: {exc}", logs=logs, prefix=prefix, stderr=True)
+        return 127
+    if process.stdout is None:
+        raise RuntimeError("subprocess stdout pipe was not created")
+    reader_errors: list[BaseException] = []
+
+    def _read_stdout() -> None:
+        try:
+            assert process.stdout is not None
+            for line in process.stdout:
+                emit(line.rstrip("\n"), logs=logs, prefix=prefix)
+        except ValueError:
+            pass
+        except BaseException as exc:
+            reader_errors.append(exc)
+
+    reader = threading.Thread(target=_read_stdout, daemon=True)
+    reader.start()
+    timed_out = False
+    try:
+        status = process.wait(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        emit(
+            f"Command timed out after {timeout_seconds} seconds; terminating process.",
+            logs=logs,
+            prefix=prefix,
+            stderr=True,
+        )
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            emit("Process did not terminate; killing process.", logs=logs, prefix=prefix, stderr=True)
+            process.kill()
+            process.wait()
+        status = 124
+    finally:
+        if process.stdout is not None:
+            with suppress(OSError, ValueError):
+                process.stdout.close()
+        reader.join(timeout=2)
+    if reader.is_alive():
+        emit("Output reader thread did not stop within 2 seconds.", logs=logs, prefix=prefix, stderr=True)
+    for error in reader_errors:
+        emit(f"Output reader error: {type(error).__name__}: {error}", logs=logs, prefix=prefix, stderr=True)
+    return 124 if timed_out else status
+
+
+def command_stdout_to_file(
+    command: list[str],
+    output_path: Path,
+    *,
+    logs: Iterable[Path] = (),
+    prefix: str | None = None,
+) -> int:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with output_path.open("w", encoding="utf-8", errors="replace") as stdout:
+            process = subprocess.Popen(
+                command,
+                stdout=stdout,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+            if process.stderr is None:
+                raise RuntimeError("subprocess stderr pipe was not created")
+            for line in process.stderr:
+                emit(line.rstrip("\n"), logs=logs, prefix=prefix, stderr=True)
+            return process.wait()
+    except OSError as exc:
+        program = command[0] if command else "<empty command>"
+        emit(f"Failed to start command {program}: {type(exc).__name__}: {exc}", logs=logs, prefix=prefix, stderr=True)
+        return 127
+
+
+def add_agent_passthrough_env(args: list[str], adapter: AgentAdapter) -> None:
+    for name in adapter.passthrough_env_names():
+        if os.environ.get(name):
+            args.extend(["-e", name])
+
+
+def docker_env(name: str, value: str | int | bool | None = None) -> list[str]:
+    if value is None:
+        return ["-e", name]
+    if isinstance(value, bool):
+        rendered = "true" if value else "false"
+    else:
+        rendered = str(value)
+    return ["-e", f"{name}={rendered}"]
+
+
+def add_agent_auth_mounts(
+    args: list[str],
+    *,
+    mounts: list[DockerMount],
+    logs: Iterable[Path] = (),
+    prefix: str | None = None,
+) -> None:
+    for mount in mounts:
+        if mount.host_path.is_file():
+            suffix = ":ro" if mount.read_only else ""
+            args.extend(["-v", f"{mount.host_path}:{mount.container_path}{suffix}"])
+            label = mount.description or "agent auth/config"
+            emit(f"Mounting {label}: {mount.host_path} -> {mount.container_path}", logs=logs, prefix=prefix)
+        elif mount.required:
+            raise SystemExit(f"Required agent auth/config file is missing: {mount.host_path}")
+        else:
+            label = mount.description or "agent auth/config"
+            emit(f"{label} not mounted; missing {mount.host_path}", logs=logs, prefix=prefix, stderr=True)
+
+
+@dataclass(frozen=True)
+class ImageConfig:
+    image_name: str
+    baseline_image_name: str
+    report_image_name: str
+
+    @classmethod
+    def from_env(cls) -> "ImageConfig":
+        adapter = benchmark_agent_adapter_from_env()
+        return cls.for_adapter(adapter)
+
+    @classmethod
+    def for_adapter(cls, adapter: AgentAdapter) -> "ImageConfig":
+        targets = adapter.image_targets()
+        image = targets.skills
+        return cls(
+            image_name=image,
+            baseline_image_name=targets.baseline,
+            report_image_name=targets.report,
+        )
+
+
+@dataclass(frozen=True)
+class CaseConfig:
+    mode: str
+    use_preinstalled_skills: bool
+    job_input_dir: Path
+    result_dir: Path
+    prompt_path: Path
+    images: ImageConfig
+    progress_interval_seconds: str
+    agent: str
+    agent_model: str
+    model_was_explicit: bool
+    adapter: AgentAdapter
+    host_agent_home: Path
+    mount_host_agent_auth: bool
+    agent_timeout_seconds: int | None = None
+    container_timeout_seconds: int | None = None
+    result_size_budget_bytes: int | None = None
+
+    @property
+    def run_image(self) -> str:
+        return self.images.image_name if self.use_preinstalled_skills else self.images.baseline_image_name
+
+    @property
+    def sdk_image_kind(self) -> str:
+        return (
+            "local_wheel_with_preinstalled_skills"
+            if self.use_preinstalled_skills
+            else "local_wheel_without_packaged_skills"
+        )
+
+
+def case_config(
+    *,
+    mode: str,
+    use_preinstalled_skills: bool,
+    job_input_dir: Path,
+    result_dir: Path,
+    prompt_path: Path,
+    images: ImageConfig,
+) -> CaseConfig:
+    adapter = benchmark_agent_adapter_from_env()
+    try:
+        agent_model = adapter.model_from_env(os.environ)
+        model_was_explicit = adapter.model_was_explicit(os.environ)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    return CaseConfig(
+        mode=mode,
+        use_preinstalled_skills=use_preinstalled_skills,
+        job_input_dir=job_input_dir,
+        result_dir=result_dir,
+        prompt_path=prompt_path,
+        images=images,
+        progress_interval_seconds=os.environ.get("PROGRESS_INTERVAL_SECONDS", "60"),
+        agent=adapter.name,
+        agent_model=agent_model,
+        model_was_explicit=model_was_explicit,
+        adapter=adapter,
+        host_agent_home=absolute_path(str(adapter.host_home_from_env(os.environ))),
+        mount_host_agent_auth=adapter.mount_auth_from_env(os.environ),
+        agent_timeout_seconds=optional_int_env("AGENT_TIMEOUT_SECONDS"),
+        container_timeout_seconds=optional_int_env("CONTAINER_TIMEOUT_SECONDS"),
+        result_size_budget_bytes=optional_int_env("RESULT_SIZE_BUDGET_BYTES"),
+    )
+
+
+def optional_int_env(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an integer; got {value}") from exc
+    if parsed <= 0:
+        raise SystemExit(f"{name} must be positive; got {value}")
+    return parsed
+
+
+def docker_args_for_case(config: CaseConfig, logs: Iterable[Path] = (), prefix: str | None = None) -> list[str]:
+    runtime_env = config.adapter.runtime_env(config)
+    args = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{config.job_input_dir}:/workspace/input:ro",
+        "-v",
+        f"{config.result_dir}:/workspace/results",
+        "-v",
+        f"{config.prompt_path}:{CONTAINER_PROMPT_PATH}:ro",
+        *docker_env("JOB_INPUT_DIR", "/workspace/input"),
+        *docker_env("TRAINING_CODE", "/workspace/input"),
+        *docker_env("PROMPT_SOURCE", CONTAINER_PROMPT_PATH),
+        *docker_env("MODE", config.mode),
+        *docker_env("USE_PREINSTALLED_SKILLS", config.use_preinstalled_skills),
+        *docker_env("SDK_IMAGE_KIND", config.sdk_image_kind),
+        *docker_env("PROGRESS_INTERVAL_SECONDS", config.progress_interval_seconds),
+        *docker_env("RESULT_DIR", "/workspace/results"),
+        *docker_env("RECORDS_DIR", "/workspace/results/records"),
+        *docker_env("SDK_AGENT_RECORD", f"/workspace/results/records/{config.mode}_agent_record.json"),
+    ]
+    for name, value in sorted(runtime_env.items()):
+        args.extend(docker_env(name, value))
+    if config.agent_timeout_seconds is not None:
+        args.extend(docker_env("AGENT_TIMEOUT_SECONDS", config.agent_timeout_seconds))
+    add_agent_passthrough_env(args, config.adapter)
+    if config.mount_host_agent_auth:
+        add_agent_auth_mounts(args, mounts=config.adapter.auth_mounts(config), logs=logs, prefix=prefix)
+    args.extend(
+        [
+            config.run_image,
+            "/workspace/venv/bin/python",
+            "-m",
+            "assist_tools.skills_benchmark.skills.harness.container.agent_run",
+        ]
+    )
+    return args
+
+
+def write_runtime_image(config: CaseConfig) -> None:
+    config.result_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        config.result_dir / "runtime_image.json",
+        {
+            "mode": config.mode,
+            "use_preinstalled_skills": config.use_preinstalled_skills,
+            "agent": config.agent,
+            "agent_model": config.agent_model,
+            "agent_model_explicit": config.model_was_explicit,
+            "agent_adapter": config.adapter.metadata(),
+            "runtime_image": config.run_image,
+            "report_image": config.images.report_image_name,
+            "sdk_image_kind": config.sdk_image_kind,
+            "container_prompt_source": CONTAINER_PROMPT_PATH,
+            "container_python": "/workspace/venv/bin/python",
+            "container_virtual_env": "/workspace/venv",
+            "resource_policy": {
+                "agent_timeout_seconds": config.agent_timeout_seconds,
+                "container_timeout_seconds": config.container_timeout_seconds,
+                "result_size_budget_bytes": config.result_size_budget_bytes,
+            },
+        },
+    )
+
+
+def benchmark_agent_from_env() -> str:
+    try:
+        return validate_benchmark_agent(os.environ.get("BENCHMARK_AGENT", DEFAULT_BENCHMARK_AGENT))
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
+def benchmark_agent_adapter_from_env() -> AgentAdapter:
+    try:
+        return load_agent_adapter(os.environ.get("BENCHMARK_AGENT", DEFAULT_BENCHMARK_AGENT))
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc

--- a/assist_tools/skills_benchmark/skills/harness/host_build.py
+++ b/assist_tools/skills_benchmark/skills/harness/host_build.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility entry point for the migrated Docker image builder."""
+
+from __future__ import annotations
+
+import sys
+
+from .host.build import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/assist_tools/skills_benchmark/skills/harness/host_common.py
+++ b/assist_tools/skills_benchmark/skills/harness/host_common.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility exports for migrated host helpers."""
+
+from __future__ import annotations
+
+from .host.common import *  # noqa: F401,F403

--- a/assist_tools/skills_benchmark/skills/harness/sdks/__init__.py
+++ b/assist_tools/skills_benchmark/skills/harness/sdks/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SDK adapter plugins for benchmark Docker setup."""

--- a/assist_tools/skills_benchmark/skills/harness/sdks/base.py
+++ b/assist_tools/skills_benchmark/skills/harness/sdks/base.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SDK adapter contracts for benchmark Docker setup."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SdkWheelVariant:
+    name: str
+    label: str
+    build_env_value: str
+    wheel_globs: tuple[str, ...]
+    wheel_exclude_globs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SdkSource:
+    source_type: str
+    repo_path: Path | None = None
+    repo_markers: tuple[str, ...] = ()
+    wheel_paths: dict[str, Path] | None = None
+
+
+@dataclass(frozen=True)
+class SdkSkillsSetup:
+    setup_type: str
+    source_path: Path | None = None
+    install_command: str = ""
+    list_command: str = ""
+    install_output: str = "skills_build_install.json"
+    list_output: str = "skills_list.json"
+    expected_source: str = "local_sdk_wheel"
+
+
+@dataclass(frozen=True)
+class SdkWheelBuild:
+    build_type: str
+
+
+class SdkAdapter(ABC):
+    """Contract for SDK-specific Docker build mechanics.
+
+    The SDK adapter owns source-package details: how to find the checkout, how
+    to build/stage the skills and baseline wheels, and how to preinstall skills
+    in the runtime image. Agent adapters still own agent CLI behavior.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def display_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def package_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def import_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def build_env_name(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def source(self, *, repo_root: Path, home: Path) -> SdkSource:
+        raise NotImplementedError
+
+    @abstractmethod
+    def wheel_build(self) -> SdkWheelBuild:
+        raise NotImplementedError
+
+    @abstractmethod
+    def wheel_variant(self, name: str) -> SdkWheelVariant:
+        raise NotImplementedError
+
+    @abstractmethod
+    def skills_setup(self, *, repo_root: Path, home: Path) -> SdkSkillsSetup:
+        raise NotImplementedError
+
+    @abstractmethod
+    def docker_build_args(self) -> dict[str, str]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def metadata(self) -> dict[str, object]:
+        raise NotImplementedError

--- a/assist_tools/skills_benchmark/skills/harness/sdks/config.py
+++ b/assist_tools/skills_benchmark/skills/harness/sdks/config.py
@@ -1,0 +1,296 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""YAML-driven SDK adapter implementation."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from .base import SdkAdapter, SdkSkillsSetup, SdkSource, SdkWheelBuild, SdkWheelVariant
+
+
+def required_mapping(data: Mapping[str, Any], key: str, config_path: Path) -> dict[str, Any]:
+    value = data.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"{config_path}: {key} must be a mapping")
+    return value
+
+
+def string_tuple(value: Any, *, label: str, config_path: Path) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError(f"{config_path}: {label} must be a list")
+    return tuple(str(item) for item in value)
+
+
+def format_config_value(value: Any, values: Mapping[str, str], *, label: str, config_path: Path) -> str:
+    try:
+        return str(value).format(**values)
+    except KeyError as exc:
+        raise ValueError(f"{config_path}: unknown placeholder {{{exc.args[0]}}} in {label}") from exc
+    except ValueError as exc:
+        raise ValueError(f"{config_path}: invalid template syntax in {label}: {exc}") from exc
+
+
+def validate_skills_setup(skills: Mapping[str, Any], config_path: Path) -> None:
+    setup = required_mapping(skills, "setup", config_path)
+    setup_type = str(setup.get("type") or "")
+    if setup_type not in {"command", "copy", "none"}:
+        raise ValueError(f"{config_path}: skills.setup.type must be command, copy, or none")
+    if setup_type == "command" and not setup.get("install_command"):
+        raise ValueError(f"{config_path}: skills.setup.install_command is required for skills.setup.type=command")
+    if setup_type == "copy" and not setup.get("source_path"):
+        raise ValueError(f"{config_path}: skills.setup.source_path is required for skills.setup.type=copy")
+
+
+def validate_wheel_build(build: Mapping[str, Any], source_type: str, config_path: Path) -> None:
+    build_type = str(build.get("type") or "")
+    if build_type not in {"uv_wheel", "provided_wheels"}:
+        raise ValueError(f"{config_path}: build.type must be uv_wheel or provided_wheels")
+    if build_type == "uv_wheel" and source_type != "repo":
+        raise ValueError(f"{config_path}: build.type=uv_wheel requires source.type=repo")
+    if build_type == "provided_wheels" and source_type != "wheels":
+        raise ValueError(f"{config_path}: build.type=provided_wheels requires source.type=wheels")
+
+
+@dataclass(frozen=True)
+class SdkConfig:
+    source_path: Path
+    raw: dict[str, Any]
+    source_sha256: str
+    name: str
+    display_name: str
+    package_name: str
+    import_name: str
+    source: dict[str, Any]
+    build: dict[str, Any]
+    docker: dict[str, Any]
+    skills: dict[str, Any]
+
+    @classmethod
+    def load(cls, config_path: Path) -> "SdkConfig":
+        source = config_path.read_text(encoding="utf-8")
+        data = yaml.safe_load(source) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"{config_path} must contain a YAML object")
+        required = ("name", "display_name", "package_name", "import_name", "source", "build", "docker", "skills")
+        missing = [name for name in required if name not in data]
+        if missing:
+            raise ValueError(f"{config_path} is missing required field(s): {', '.join(missing)}")
+
+        source_config = required_mapping(data, "source", config_path)
+        source_type = str(source_config.get("type") or "")
+        if source_type not in {"repo", "wheels"}:
+            raise ValueError(f"{config_path}: source.type must be repo or wheels")
+        if source_type == "repo":
+            if not source_config.get("path"):
+                raise ValueError(f"{config_path}: source.path is required for source.type=repo")
+            markers = string_tuple(source_config.get("markers"), label="source.markers", config_path=config_path)
+            if not markers:
+                raise ValueError(f"{config_path}: source.markers must not be empty for source.type=repo")
+        else:
+            wheels = required_mapping(source_config, "wheels", config_path)
+            for variant_name in ("skills", "baseline"):
+                if not wheels.get(variant_name):
+                    raise ValueError(f"{config_path}: source.wheels.{variant_name} is required for source.type=wheels")
+
+        build = required_mapping(data, "build", config_path)
+        validate_wheel_build(build, source_type, config_path)
+        docker = required_mapping(data, "docker", config_path)
+        skills = required_mapping(data, "skills", config_path)
+        validate_skills_setup(skills, config_path)
+        variants = required_mapping(build, "variants", config_path)
+        for variant_name in ("skills", "baseline"):
+            variant = required_mapping(variants, variant_name, config_path)
+            wheel_globs = string_tuple(
+                variant.get("wheel_globs"),
+                label=f"build.variants.{variant_name}.wheel_globs",
+                config_path=config_path,
+            )
+            if not wheel_globs:
+                raise ValueError(f"{config_path}: build.variants.{variant_name}.wheel_globs must not be empty")
+
+        return cls(
+            source_path=config_path,
+            raw=data,
+            source_sha256=hashlib.sha256(source.encode("utf-8")).hexdigest(),
+            name=str(data["name"]),
+            display_name=str(data["display_name"]),
+            package_name=str(data["package_name"]),
+            import_name=str(data["import_name"]),
+            source=source_config,
+            build=build,
+            docker=docker,
+            skills=skills,
+        )
+
+
+class ConfigurableSdkAdapter(SdkAdapter):
+    """Concrete SDK adapter driven by a validated YAML config."""
+
+    def __init__(self, config_path: Path) -> None:
+        self._cfg = SdkConfig.load(config_path)
+
+    @property
+    def name(self) -> str:
+        return self._cfg.name
+
+    @property
+    def display_name(self) -> str:
+        return self._cfg.display_name
+
+    @property
+    def package_name(self) -> str:
+        return self._cfg.package_name
+
+    @property
+    def import_name(self) -> str:
+        return self._cfg.import_name
+
+    @property
+    def build_env_name(self) -> str:
+        return str(self._cfg.build.get("env_name") or "")
+
+    def wheel_build(self) -> SdkWheelBuild:
+        return SdkWheelBuild(build_type=str(self._cfg.build.get("type") or ""))
+
+    def source(self, *, repo_root: Path, home: Path) -> SdkSource:
+        values = {
+            "repo_root": str(repo_root),
+            "home": str(home),
+        }
+        source_type = str(self._cfg.source.get("type"))
+        if source_type == "repo":
+            repo_path = Path(
+                format_config_value(
+                    self._cfg.source["path"],
+                    values,
+                    label="source.path",
+                    config_path=self._cfg.source_path,
+                )
+            ).expanduser()
+            return SdkSource(
+                source_type="repo",
+                repo_path=repo_path,
+                repo_markers=string_tuple(
+                    self._cfg.source.get("markers"),
+                    label="source.markers",
+                    config_path=self._cfg.source_path,
+                ),
+            )
+        wheels = required_mapping(self._cfg.source, "wheels", self._cfg.source_path)
+        return SdkSource(
+            source_type="wheels",
+            wheel_paths={
+                "skills": Path(
+                    format_config_value(
+                        wheels["skills"],
+                        values,
+                        label="source.wheels.skills",
+                        config_path=self._cfg.source_path,
+                    )
+                ).expanduser(),
+                "baseline": Path(
+                    format_config_value(
+                        wheels["baseline"],
+                        values,
+                        label="source.wheels.baseline",
+                        config_path=self._cfg.source_path,
+                    )
+                ).expanduser(),
+            },
+        )
+
+    def wheel_variant(self, name: str) -> SdkWheelVariant:
+        variants = required_mapping(self._cfg.build, "variants", self._cfg.source_path)
+        if name not in variants:
+            raise ValueError(f"{self._cfg.source_path}: unknown SDK wheel variant {name!r}")
+        raw = required_mapping(variants, name, self._cfg.source_path)
+        wheel_globs = string_tuple(
+            raw.get("wheel_globs"),
+            label=f"build.variants.{name}.wheel_globs",
+            config_path=self._cfg.source_path,
+        )
+        wheel_exclude_globs = string_tuple(
+            raw.get("wheel_exclude_globs"),
+            label=f"build.variants.{name}.wheel_exclude_globs",
+            config_path=self._cfg.source_path,
+        )
+        return SdkWheelVariant(
+            name=name,
+            label=str(raw.get("label") or name),
+            build_env_value=str(raw.get("build_env_value", "")),
+            wheel_globs=wheel_globs,
+            wheel_exclude_globs=wheel_exclude_globs,
+        )
+
+    def skills_setup(self, *, repo_root: Path, home: Path) -> SdkSkillsSetup:
+        values = {
+            "repo_root": str(repo_root),
+            "home": str(home),
+        }
+        raw = required_mapping(self._cfg.skills, "setup", self._cfg.source_path)
+        setup_type = str(raw.get("type") or "")
+        source_path = raw.get("source_path")
+        return SdkSkillsSetup(
+            setup_type=setup_type,
+            source_path=(
+                Path(
+                    format_config_value(
+                        source_path,
+                        values,
+                        label="skills.setup.source_path",
+                        config_path=self._cfg.source_path,
+                    )
+                ).expanduser()
+                if source_path
+                else None
+            ),
+            install_command=str(raw.get("install_command", "")),
+            list_command=str(raw.get("list_command", "")),
+            install_output=str(raw.get("install_output", "skills_build_install.json")),
+            list_output=str(raw.get("list_output", "skills_list.json")),
+            expected_source=str(raw.get("expected_source", "local_sdk_wheel")),
+        )
+
+    def docker_build_args(self) -> dict[str, str]:
+        setup = self.skills_setup(repo_root=Path(), home=Path.home())
+        return {
+            "SDK_PACKAGE_NAME": self.package_name,
+            "SDK_IMPORT_NAME": self.import_name,
+            "SDK_VERSION_COMMAND": str(self._cfg.docker.get("version_command", "")),
+            "SKILLS_SETUP_TYPE": setup.setup_type,
+            "SKILLS_INSTALL_COMMAND": setup.install_command,
+            "SKILLS_LIST_COMMAND": setup.list_command,
+            "SKILLS_INSTALL_OUTPUT": setup.install_output,
+            "SKILLS_LIST_OUTPUT": setup.list_output,
+            "SKILLS_INSTALL_EXPECTED_SOURCE": setup.expected_source,
+        }
+
+    def metadata(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "package_name": self.package_name,
+            "import_name": self.import_name,
+            "source_path": str(self._cfg.source_path),
+            "source_sha256": self._cfg.source_sha256,
+        }

--- a/assist_tools/skills_benchmark/skills/harness/sdks/registry.py
+++ b/assist_tools/skills_benchmark/skills/harness/sdks/registry.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SDK adapter registry for benchmark Docker setup."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from .base import SdkAdapter
+from .config import ConfigurableSdkAdapter
+
+BENCHMARK_ROOT = Path(__file__).resolve().parents[3]
+SDK_CONFIG_DIR = BENCHMARK_ROOT / "config" / "sdks"
+DEFAULT_BENCHMARK_SDK = "nvflare-profile"
+
+
+def sdk_config_path(sdk: str) -> Path:
+    if Path(sdk).name != sdk or sdk.startswith("."):
+        raise ValueError(f"SDK profile must be a config name, got {sdk!r}")
+    return SDK_CONFIG_DIR / f"{sdk}.yaml"
+
+
+def supported_sdk_names() -> tuple[str, ...]:
+    return tuple(sorted(path.stem for path in SDK_CONFIG_DIR.glob("*.yaml") if not path.name.startswith(".")))
+
+
+def validate_benchmark_sdk(sdk: str) -> str:
+    config_path = sdk_config_path(sdk)
+    if not config_path.is_file():
+        supported = ", ".join(supported_sdk_names())
+        raise ValueError(f"Unsupported SDK profile {sdk!r}. Supported SDK profiles: {supported}.")
+    return sdk
+
+
+@lru_cache(maxsize=None)
+def get_sdk_adapter(sdk: str) -> SdkAdapter:
+    name = validate_benchmark_sdk(sdk)
+    return ConfigurableSdkAdapter(sdk_config_path(name))
+
+
+def load_sdk_adapter(sdk: str) -> SdkAdapter:
+    return get_sdk_adapter(sdk)
+
+
+def clear_sdk_adapter_cache() -> None:
+    get_sdk_adapter.cache_clear()

--- a/tests/unit_test/skills_benchmark/conftest.py
+++ b/tests/unit_test/skills_benchmark/conftest.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pytest setup for skills benchmark harness tests."""

--- a/tests/unit_test/skills_benchmark/skills_benchmark_agent_configs_test.py
+++ b/tests/unit_test/skills_benchmark/skills_benchmark_agent_configs_test.py
@@ -1,0 +1,943 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+from pathlib import Path
+
+
+def test_codex_event_normalizer_returns_agent_event():
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    event = load_agent_adapter("codex").normalize_event('{"type": "turn", "message": "ok"}')
+
+    assert event["type"] == "turn"
+    assert event["message"] == "ok"
+    assert re.match(r"\d{4}-\d{2}-\d{2}T", event["harness_timestamp"])
+
+
+def test_known_pending_agent_event_normalizer_fails_fast():
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    try:
+        load_agent_adapter("hermes")
+    except ValueError as exc:
+        assert "BENCHMARK_AGENT='hermes'" in str(exc)
+        assert "known but not implemented" in str(exc)
+    else:
+        raise AssertionError("unsupported benchmark agent should fail before event parsing")
+
+
+def test_codex_agent_config_loads_parser_and_classifier_ids():
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    config_path = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "config" / "agents" / "codex.yaml"
+    )
+
+    config = AgentConfig.load(config_path)
+
+    assert config.name == "codex"
+    assert config.events.parser == "codex_jsonl"
+    assert config.usage.parser == "codex_cumulative_usage"
+    assert config.activity.parser == "codex_jsonl_activity"
+    assert config.exit_classifier == "stderr_patterns"
+    assert config.exit_config["rules"]
+    assert "{prompt_text}" not in json.dumps(config.raw)
+
+
+def test_claude_agent_config_uses_config_dir_and_valid_final_message_source():
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    config_path = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "config" / "agents" / "claude.yaml"
+    )
+
+    config = AgentConfig.load(config_path)
+
+    assert config.agent_home_env == "CLAUDE_CONFIG_DIR"
+    assert config.requires_explicit_model is True
+    assert config.final_message["source_type"] == "structured_event"
+    assert config.events.parser == "claude_stream_json"
+    assert config.usage.parser == "claude_stream_usage"
+    assert config.activity.parser == "claude_stream_activity"
+    assert config.exit_classifier == "stderr_patterns"
+    assert config.exit_config["rules"]
+    assert "model_argv" not in config.launch
+
+
+def test_adapter_template_rejects_positional_placeholders():
+    from assist_tools.skills_benchmark.skills.harness.agents.config import render_string
+
+    try:
+        render_string("agent {}", {"agent": "codex"})
+    except ValueError as exc:
+        assert "positional" in str(exc)
+    else:
+        raise AssertionError("adapter templates should reject positional placeholders")
+
+
+def test_adapter_template_rejects_attribute_and_index_access():
+    from assist_tools.skills_benchmark.skills.harness.agents.config import render_string
+
+    for template in ("{workspace_dir.parent}", "{argv[0]}"):
+        try:
+            render_string(template, {"workspace_dir": "workspace", "argv": ["agent"]})
+        except ValueError as exc:
+            assert "attribute or index access" in str(exc)
+        else:
+            raise AssertionError("adapter templates should reject attribute and index access")
+
+
+def test_claude_adapter_launch_spec_uses_stream_json_without_prompt_text(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import AgentLaunchContext
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    result_dir = tmp_path / "results"
+    workspace_dir = tmp_path / "workspace"
+    prompt_file = tmp_path / "prompt.txt"
+    result_dir.mkdir()
+    workspace_dir.mkdir()
+    prompt_file.write_text("Convert this job.\n", encoding="utf-8")
+    config = AgentLaunchContext(
+        model="claude-test",
+        model_was_explicit=True,
+        result_dir=result_dir,
+        workspace_dir=workspace_dir,
+        prompt_file=prompt_file,
+        events_dest=result_dir / "agent_events.jsonl",
+        stderr_dest=result_dir / "agent_stderr.txt",
+        final_message_dest=result_dir / "agent_last_message.txt",
+    )
+
+    spec = load_agent_adapter("claude").launch_spec(config)
+
+    rendered_argv = " ".join(spec.argv)
+    assert spec.prompt_input_mode == "stdin"
+    assert "--output-format" in spec.argv
+    assert "stream-json" in spec.argv
+    assert "--dangerously-skip-permissions" in spec.sandbox_flags
+    assert "Convert this job" not in rendered_argv
+    assert "claude-test" in spec.argv
+    assert spec.argv[spec.argv.index("--model") + 1] == "claude-test"
+
+
+def test_claude_adapter_requires_explicit_model():
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("claude")
+
+    try:
+        adapter.model_from_env({})
+    except ValueError as exc:
+        assert "requires an explicit benchmark model" in str(exc)
+        assert "BENCHMARK_AGENT_MODEL" in str(exc)
+    else:
+        raise AssertionError("Claude benchmark runs must require an explicit model")
+
+
+def test_runtime_env_uses_agent_run_config_model_explicit_field():
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    class Config:
+        agent_model = "claude-test"
+        agent_model_was_explicit = True
+
+    env = load_agent_adapter("claude").runtime_env(Config())
+
+    assert env["BENCHMARK_AGENT_MODEL"] == "claude-test"
+
+
+def test_runtime_env_rejects_unexplicit_model_for_required_agent():
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    class Config:
+        agent_model = "unspecified_default"
+        agent_model_was_explicit = False
+
+    try:
+        load_agent_adapter("claude").runtime_env(Config())
+    except ValueError as exc:
+        assert "requires an explicit benchmark model before runtime setup" in str(exc)
+        assert "BENCHMARK_AGENT_MODEL" in str(exc)
+    else:
+        raise AssertionError("availability/runtime setup should enforce required explicit models")
+
+
+def test_claude_launch_spec_rejects_unexplicit_model_context(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import AgentLaunchContext
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    result_dir = tmp_path / "results"
+    workspace_dir = tmp_path / "workspace"
+    prompt_file = tmp_path / "prompt.txt"
+    result_dir.mkdir()
+    workspace_dir.mkdir()
+    prompt_file.write_text("Convert this job.\n", encoding="utf-8")
+    context = AgentLaunchContext(
+        model="unspecified_default",
+        model_was_explicit=False,
+        result_dir=result_dir,
+        workspace_dir=workspace_dir,
+        prompt_file=prompt_file,
+        events_dest=result_dir / "agent_events.jsonl",
+        stderr_dest=result_dir / "agent_stderr.txt",
+        final_message_dest=result_dir / "agent_last_message.txt",
+    )
+
+    try:
+        load_agent_adapter("claude").launch_spec(context)
+    except ValueError as exc:
+        assert "requires an explicit benchmark model before launch" in str(exc)
+        assert "BENCHMARK_AGENT_MODEL" in str(exc)
+    else:
+        raise AssertionError("Claude launch spec must reject implicit CLI model defaults")
+
+
+def test_claude_stream_parser_normalizes_event_usage_and_activity(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("claude")
+    events_path = tmp_path / "agent_events.jsonl"
+    raw_events = [
+        {
+            "type": "system",
+            "subtype": "init",
+            "session_id": "session-1",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "running"},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "python job.py --export"}},
+                ],
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "result": "Final AUROC 0.75",
+            "total_cost_usd": 0.01,
+            "message": {
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                }
+            },
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_creation_input_tokens": 3,
+                "cache_read_input_tokens": 7,
+            },
+        },
+    ]
+    with events_path.open("w", encoding="utf-8") as stream:
+        for raw_event in raw_events:
+            normalized = adapter.normalize_event(json.dumps(raw_event))
+            stream.write(json.dumps(normalized) + "\n")
+
+    usage = adapter.parse_usage(events_path)
+    activity = adapter.parse_activity(events_path)
+
+    assert usage["parser_id"] == "claude_stream_usage"
+    assert usage["total_tokens"] == 130
+    assert usage["cache_tokens"] == 10
+    assert usage["cost"] == 0.01
+    assert usage["parser_warnings"] == []
+    assert usage["total_cost_usd"] == 0.01
+    assert activity["parser_id"] == "claude_stream_activity"
+    assert activity["event_types"]["result.success"] == 1
+    assert activity["tool_counts"]["Bash"] == 1
+    assert activity["commands"] == ["python job.py --export"]
+    result_event = json.loads(events_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert result_event["final_message"] == "Final AUROC 0.75"
+    assistant_event = json.loads(events_path.read_text(encoding="utf-8").splitlines()[1])
+    assert assistant_event.get("command_text") == "python job.py --export"
+    assert "command" not in assistant_event
+
+
+def test_generic_event_usage_and_activity_share_cached_parse(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from assist_tools.skills_benchmark.skills.harness.agents import parsers
+
+    events_path = tmp_path / "agent_events.jsonl"
+    events_path.write_text("{}\n", encoding="utf-8")
+    calls = {"count": 0}
+
+    def counted_parse(path):
+        calls["count"] += 1
+        assert path == events_path
+        return {"total_tokens": 7}, {"event_count": 1}
+
+    parsers.parse_cached_usage_and_activity.cache_clear()
+    monkeypatch.setattr(parsers, "parse_usage_and_activity_data", counted_parse)
+
+    usage = parsers.parse_usage_from_events(events_path, SimpleNamespace(parser="codex_cumulative_usage"))
+    activity = parsers.parse_activity_from_events(events_path, SimpleNamespace(parser="codex_jsonl_activity"))
+
+    assert usage == {"total_tokens": 7, "parser_id": "codex_cumulative_usage"}
+    assert activity == {"event_count": 1, "parser_id": "codex_jsonl_activity"}
+    assert calls["count"] == 1
+    parsers.parse_cached_usage_and_activity.cache_clear()
+
+
+def test_claude_stream_usage_falls_back_when_result_usage_is_zero(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("claude")
+    events_path = tmp_path / "agent_events.jsonl"
+    raw_events = [
+        {
+            "type": "assistant",
+            "message": {
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "cache_creation_input_tokens": 2,
+                    "cache_read_input_tokens": 3,
+                }
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        },
+    ]
+    with events_path.open("w", encoding="utf-8") as stream:
+        for raw_event in raw_events:
+            stream.write(json.dumps(adapter.normalize_event(json.dumps(raw_event))) + "\n")
+
+    usage = adapter.parse_usage(events_path)
+
+    assert usage["total_tokens"] == 20
+    assert usage["cache_tokens"] == 5
+    assert "no nonzero token fields" in usage["parser_warnings"][0]
+
+
+def test_claude_stream_usage_accumulates_multiple_result_events(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("claude")
+    events_path = tmp_path / "agent_events.jsonl"
+    raw_events = [
+        {
+            "type": "assistant",
+            "message": {
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_creation_input_tokens": 10,
+                    "cache_read_input_tokens": 20,
+                }
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cache_creation_input_tokens": 1,
+                "cache_read_input_tokens": 2,
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "usage": {
+                "input_tokens": 20,
+                "output_tokens": 7,
+                "cache_creation_input_tokens": 3,
+                "cache_read_input_tokens": 4,
+            },
+        },
+    ]
+    with events_path.open("w", encoding="utf-8") as stream:
+        for raw_event in raw_events:
+            stream.write(json.dumps(adapter.normalize_event(json.dumps(raw_event))) + "\n")
+
+    usage = adapter.parse_usage(events_path)
+
+    assert usage["total_tokens"] == 34
+    assert usage["cache_tokens"] == 7
+    assert usage["result_usage_objects_seen"] == 2
+    assert "final cumulative result usage was used" in usage["parser_warnings"][0]
+
+
+def test_claude_stream_parser_ignores_non_shell_tool_command_fields(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("claude")
+    raw_event = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "tool_use", "name": "Notebook", "input": {"command": "not a shell command"}},
+            ],
+        },
+    }
+
+    normalized = adapter.normalize_event(json.dumps(raw_event))
+
+    assert "command_text" not in normalized
+
+
+def test_claude_stream_parser_uses_exact_shell_tool_allowlist():
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("claude")
+    raw_event = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {"type": "tool_use", "name": "BashRunner", "input": {"command": "python job.py"}},
+            ],
+        },
+    }
+
+    normalized = adapter.normalize_event(json.dumps(raw_event))
+
+    assert "command_text" not in normalized
+
+
+def test_claude_final_message_source_materializes_structured_result_event(tmp_path):
+    from collections import deque
+
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        materialize_final_message,
+    )
+
+    adapter = load_agent_adapter("claude")
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=tmp_path / "run",
+        prompt_source=tmp_path / "prompt.txt",
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="claude",
+        agent_model="claude-test",
+        agent_home=tmp_path / ".claude",
+        agent_model_was_explicit=True,
+    )
+    with config.agent_events_path.open("w", encoding="utf-8") as stream:
+        stream.write(json.dumps(adapter.normalize_event(json.dumps({"type": "assistant", "message": {}}))) + "\n")
+        stream.write(
+            json.dumps(
+                adapter.normalize_event(
+                    json.dumps({"type": "result", "subtype": "success", "result": "Final Claude response"})
+                )
+            )
+            + "\n"
+        )
+
+    materialize_final_message(config, adapter, deque())
+
+    assert config.agent_last_message_path.read_text(encoding="utf-8") == "Final Claude response"
+    metadata = json.loads((result_dir / "final_message_source.json").read_text(encoding="utf-8"))
+    assert metadata["source_type"] == "structured_event"
+    assert metadata["status"] == "materialized"
+    assert metadata["parser_warnings"]
+
+
+def test_structured_final_message_not_read_when_stdout_reader_active(tmp_path):
+    from collections import deque
+
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        materialize_final_message,
+    )
+
+    adapter = load_agent_adapter("claude")
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=tmp_path / "run",
+        prompt_source=tmp_path / "prompt.txt",
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="claude",
+        agent_model="claude-test",
+        agent_home=tmp_path / ".claude",
+        agent_model_was_explicit=True,
+    )
+    with config.agent_events_path.open("w", encoding="utf-8") as stream:
+        stream.write(
+            json.dumps(
+                adapter.normalize_event(
+                    json.dumps({"type": "result", "subtype": "success", "result": "Final Claude response"})
+                )
+            )
+            + "\n"
+        )
+
+    materialize_final_message(config, adapter, deque(), stdout_tail_truncated=True)
+
+    assert config.agent_last_message_path.read_text(encoding="utf-8") == ""
+    metadata = json.loads((result_dir / "final_message_source.json").read_text(encoding="utf-8"))
+    assert metadata["status"] == "missing"
+    assert metadata["stdout_tail_truncated"] is True
+    assert "still active" in metadata["message"]
+
+
+def test_launch_spec_metadata_records_sandbox_flags_and_bypass_reason(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.base import AgentLaunchSpec, SkillExposureResult
+    from assist_tools.skills_benchmark.skills.harness.container.agent_run import (
+        AgentRunConfig,
+        write_launch_spec_metadata,
+    )
+
+    result_dir = tmp_path / "results"
+    result_dir.mkdir()
+    config = AgentRunConfig(
+        mode="with_skills",
+        use_preinstalled_skills=True,
+        job_input_dir=tmp_path / "job",
+        result_dir=result_dir,
+        records_dir=result_dir / "records",
+        run_root=tmp_path / "run",
+        prompt_source=tmp_path / "prompt.txt",
+        progress_interval_seconds=0,
+        sdk_image_kind="test-skills",
+        agent="claude",
+        agent_model="claude-test",
+        agent_home=tmp_path / ".claude",
+        agent_model_was_explicit=True,
+    )
+    launch = AgentLaunchSpec(
+        argv=["claude", "--dangerously-skip-permissions", "--print"],
+        cwd=tmp_path,
+        prompt_file=tmp_path / "prompt.txt",
+        prompt_input_mode="stdin",
+        stdout_events_dest=result_dir / "agent_events.jsonl",
+        stderr_dest=result_dir / "agent_stderr.txt",
+        final_message_dest=result_dir / "agent_last_message.txt",
+        environment={"CLAUDE_CONFIG_DIR": "/workspace/.claude"},
+        sandbox_flags=["--dangerously-skip-permissions"],
+        bypass_reason="isolated benchmark container",
+        launch_timeout=10,
+    )
+    skill_exposure = SkillExposureResult(
+        status="prepared",
+        mechanism_type="launch_flag",
+        launch_args=["--add-dir", "/workspace/.claude/skills"],
+        environment={"CLAUDE_CONFIG_DIR": "/workspace/.claude"},
+    )
+
+    write_launch_spec_metadata(
+        config,
+        [*launch.argv, *skill_exposure.launch_args],
+        {**launch.environment, **skill_exposure.environment},
+        launch,
+        skill_exposure,
+    )
+
+    metadata = json.loads((result_dir / "launch_spec_metadata.json").read_text(encoding="utf-8"))
+    assert metadata["sandbox_flags"] == ["--dangerously-skip-permissions"]
+    assert metadata["bypass_reason"] == "isolated benchmark container"
+    assert metadata["skill_launch_args"] == ["--add-dir", "/workspace/.claude/skills"]
+    assert metadata["environment_keys"] == ["CLAUDE_CONFIG_DIR"]
+
+
+def test_claude_exit_classifier_detects_auth_and_model_failures(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("claude")
+    stderr = tmp_path / "stderr.txt"
+    stderr.write_text("Authentication failed: please login to Claude Code.\n", encoding="utf-8")
+
+    auth_summary = adapter.exit_summary(1, stderr)
+    stderr.write_text("Model is not supported in this account.\n", encoding="utf-8")
+    model_summary = adapter.exit_summary(1, stderr)
+    stderr.write_text("Permission approval is required.\n", encoding="utf-8")
+    permission_summary = adapter.exit_summary(1, stderr)
+
+    assert auth_summary["classifier"] == "stderr_patterns"
+    assert auth_summary["failure_category"] == "agent_auth_failure"
+    assert model_summary["failure_category"] == "agent_model_unsupported"
+    assert permission_summary["failure_category"] == "agent_sandbox_or_approval_failure"
+
+
+def test_codex_exit_classifier_prioritizes_missing_cli_over_stderr_text(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("codex")
+    stderr = tmp_path / "stderr.txt"
+    stderr.write_text("Authentication failed because command was not found.\n", encoding="utf-8")
+
+    summary = adapter.exit_summary(127, stderr)
+
+    assert summary["failure_category"] == "agent_cli_missing"
+
+
+def test_agent_config_rejects_unknown_parser_id(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    source_path = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "config" / "agents" / "codex.yaml"
+    )
+    config_path = tmp_path / "bad_parser.yaml"
+    config_path.write_text(source_path.read_text(encoding="utf-8").replace("codex_jsonl", "missing_parser", 1))
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "Unknown agent event parser: missing_parser" in str(exc)
+    else:
+        raise AssertionError("unknown adapter event parser should fail during config load")
+
+
+def test_agent_config_rejects_unknown_exit_classifier(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    source_path = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "config" / "agents" / "codex.yaml"
+    )
+    config_path = tmp_path / "bad_exit.yaml"
+    config_path.write_text(
+        source_path.read_text(encoding="utf-8").replace("classifier: stderr_patterns", "classifier: bad")
+    )
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "Unknown agent exit classifier: bad" in str(exc)
+    else:
+        raise AssertionError("unknown adapter exit classifier should fail during config load")
+
+
+def test_agent_config_rejects_unknown_final_message_source_type(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    source_path = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "config" / "agents" / "codex.yaml"
+    )
+    config_path = tmp_path / "bad_final_source.yaml"
+    config_path.write_text(source_path.read_text(encoding="utf-8").replace("source_type: file", "source_type: bad"))
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "Unknown final message source_type: bad" in str(exc)
+    else:
+        raise AssertionError("unknown final message source type should fail during config load")
+
+
+def test_agent_config_rejects_unknown_final_message_parser(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    source_path = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "config" / "agents" / "claude.yaml"
+    )
+    config_path = tmp_path / "bad_final_parser.yaml"
+    config_path.write_text(
+        source_path.read_text(encoding="utf-8").replace(
+            "parser: generic_structured_event_message", "parser: missing_final_parser"
+        )
+    )
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "Unknown final message parser: missing_final_parser" in str(exc)
+    else:
+        raise AssertionError("unknown final message parser should fail during config load")
+
+
+def test_agent_config_rejects_model_argv_without_explicit_position(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    source_path = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "config" / "agents" / "codex.yaml"
+    )
+    config_path = tmp_path / "bad_model_argv.yaml"
+    config_path.write_text(
+        source_path.read_text(encoding="utf-8").replace("  model_argv_position: before_stdin_sentinel\n", ""),
+        encoding="utf-8",
+    )
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "launch.model_argv_position" in str(exc)
+    else:
+        raise AssertionError("model_argv must declare an explicit placement policy")
+
+
+def test_agent_config_rejects_append_model_argv_for_stdin_prompt(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    source_path = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "config" / "agents" / "codex.yaml"
+    )
+    config_path = tmp_path / "bad_model_argv_position.yaml"
+    config_path.write_text(
+        source_path.read_text(encoding="utf-8").replace(
+            "model_argv_position: before_stdin_sentinel", "model_argv_position: append"
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "launch.model_argv_position=append is not valid with stdin prompt delivery" in str(exc)
+    else:
+        raise AssertionError("stdin model_argv must not append after the prompt sentinel")
+
+
+def test_agent_config_rejects_unknown_when_condition(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    source_path = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "config" / "agents" / "codex.yaml"
+    )
+    config_path = tmp_path / "bad_when.yaml"
+    config_path.write_text(
+        source_path.read_text(encoding="utf-8").replace(
+            "  argv:\n",
+            "  argv:\n" "    - when: use_stict_mode\n" "      args:\n" "        - --strict\n",
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "unknown condition 'use_stict_mode'" in str(exc)
+    else:
+        raise AssertionError("unknown when conditions should fail during adapter config load")
+
+
+def test_agent_adapter_cache_can_be_cleared_for_tests():
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import (
+        clear_agent_adapter_cache,
+        load_agent_adapter,
+    )
+
+    first = load_agent_adapter("codex")
+    clear_agent_adapter_cache()
+    second = load_agent_adapter("codex")
+
+    assert first is not second
+
+
+def test_codex_adapter_build_args_come_from_profile():
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("codex")
+    build_args = adapter.build_args()
+    assert build_args["BENCHMARK_DOCKER_AGENT"] == "codex"
+    assert build_args["BENCHMARK_AGENT_HOME"] == "/workspace/.codex"
+    assert build_args["AGENT_CLI_NAME"] == "codex"
+    assert build_args["AGENT_INSTALL_COMMAND"] == 'npm install -g "@openai/codex@0.137.0"'
+    assert build_args["AGENT_VERSION_COMMAND"] == "codex --version"
+
+
+def test_claude_adapter_build_auth_and_skill_exposure_contract(tmp_path):
+    from types import SimpleNamespace
+
+    from assist_tools.skills_benchmark.skills.harness.agents.base import SkillExposureContext
+    from assist_tools.skills_benchmark.skills.harness.agents.registry import load_agent_adapter
+
+    adapter = load_agent_adapter("claude")
+    build_args = adapter.build_args()
+
+    assert build_args["BENCHMARK_DOCKER_AGENT"] == "claude"
+    assert build_args["BENCHMARK_AGENT_HOME"] == "/workspace/.claude"
+    assert build_args["AGENT_CLI_NAME"] == "claude"
+    assert build_args["AGENT_INSTALL_COMMAND"] == 'npm install -g "@anthropic-ai/claude-code@latest"'
+    assert build_args["AGENT_VERSION_COMMAND"] == "claude --version"
+    assert "ANTHROPIC_API_KEY" in adapter.passthrough_env_names()
+
+    host_home = tmp_path / ".claude"
+    host_home.mkdir()
+    (host_home / ".credentials.json").write_text("{}\n", encoding="utf-8")
+    mounts = adapter.auth_mounts(SimpleNamespace(host_agent_home=host_home))
+    assert any(mount.container_path == "/workspace/.claude/.credentials.json" for mount in mounts)
+
+    spec = adapter.skill_exposure(
+        SkillExposureContext(
+            result_dir=tmp_path / "results",
+            container_home=tmp_path / ".claude-container",
+            mode="with_skills",
+            skills_enabled=True,
+            sdk_image_kind="test-skills",
+        )
+    )
+    assert spec.mechanism_type == "launch_flag"
+    assert spec.launch_args == ["--add-dir", str(tmp_path / ".claude-container" / "skills")]
+    assert spec.metadata_files == []
+
+
+def test_shared_dockerfile_uses_profile_agent_install_commands():
+    dockerfile = (
+        Path(__file__).resolve().parents[3] / "assist_tools" / "skills_benchmark" / "docker" / "Dockerfile"
+    ).read_text(encoding="utf-8")
+
+    assert "AGENT_INSTALL_COMMAND" in dockerfile
+    assert "AGENT_VERSION_COMMAND" in dockerfile
+    assert 'BENCHMARK_DOCKER_AGENT}" = "codex"' not in dockerfile
+    assert "@openai/codex" not in dockerfile
+    assert "@anthropic-ai/claude-code" not in dockerfile
+    assert "/workspace/.codex /workspace/.claude" not in dockerfile
+
+
+def test_sdk_skills_setup_default_agent_home_is_neutral(monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container import sdk_skills_setup
+
+    monkeypatch.delenv("BENCHMARK_AGENT_HOME", raising=False)
+
+    assert sdk_skills_setup.agent_home() == Path("/workspace/agent-home")
+
+
+def test_adapter_auth_mounts_reject_path_components(tmp_path):
+    from types import SimpleNamespace
+
+    import yaml
+
+    from assist_tools.skills_benchmark.skills.harness.agents.config import ConfigurableAgentAdapter
+
+    config_path = tmp_path / "bad-agent.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "bad",
+                "display_name": "Bad",
+                "agent_home_env": "BAD_HOME",
+                "container_home": "/workspace/.bad",
+                "launch": {
+                    "argv": ["bad", "{prompt_file}"],
+                    "prompt_input_mode": "file_arg",
+                },
+                "skill_exposure": {"mechanism_type": "none"},
+                "final_message": {"source_type": "not_available"},
+                "events": {"parser": "generic_jsonl"},
+                "usage": {"parser": "generic_cli_usage"},
+                "activity": {"parser": "generic_jsonl_activity"},
+                "exit": {"classifier": "generic_cli"},
+                "auth": {"files": [{"source": "../token.json", "target": "token.json"}]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    adapter = ConfigurableAgentAdapter(config_path)
+
+    try:
+        adapter.auth_mounts(SimpleNamespace(host_agent_home=tmp_path))
+    except ValueError as exc:
+        assert "auth file source must be a file name" in str(exc)
+    else:
+        raise AssertionError("auth mount source paths should not escape the configured agent home")
+
+
+def test_agent_config_rejects_unknown_skill_exposure_mechanism(tmp_path):
+    import yaml
+
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    config_path = tmp_path / "bad-agent.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "bad",
+                "display_name": "Bad",
+                "agent_home_env": "BAD_HOME",
+                "container_home": "/workspace/.bad",
+                "launch": {
+                    "argv": ["bad", "{prompt_file}"],
+                    "prompt_input_mode": "file_arg",
+                },
+                "skill_exposure": {"mechanism_type": "magic_marketplace"},
+                "final_message": {"source_type": "not_available"},
+                "events": {"parser": "generic_jsonl"},
+                "usage": {"parser": "generic_cli_usage"},
+                "activity": {"parser": "generic_jsonl_activity"},
+                "exit": {"classifier": "generic_cli"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "skill_exposure.mechanism_type" in str(exc)
+        assert "preinstalled_home" in str(exc)
+        assert "launch_flag" in str(exc)
+    else:
+        raise AssertionError("adapter configs should reject unsupported skill exposure mechanisms")
+
+
+def test_agent_config_rejects_unsafe_legacy_artifact_prefix(tmp_path):
+    import yaml
+
+    from assist_tools.skills_benchmark.skills.harness.agents.config import AgentConfig
+
+    config_path = tmp_path / "bad-agent.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "bad",
+                "display_name": "Bad",
+                "agent_home_env": "BAD_HOME",
+                "container_home": "/workspace/.bad",
+                "legacy_artifact_prefixes": ["../../escape"],
+                "launch": {
+                    "argv": ["bad", "{prompt_file}"],
+                    "prompt_input_mode": "file_arg",
+                },
+                "skill_exposure": {"mechanism_type": "none"},
+                "final_message": {"source_type": "not_available"},
+                "events": {"parser": "generic_jsonl"},
+                "usage": {"parser": "generic_cli_usage"},
+                "activity": {"parser": "generic_jsonl_activity"},
+                "exit": {"classifier": "generic_cli"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        AgentConfig.load(config_path)
+    except ValueError as exc:
+        assert "legacy_artifact_prefixes" in str(exc)
+        assert "bare file prefixes" in str(exc)
+    else:
+        raise AssertionError("legacy artifact prefixes must not contain path separators")

--- a/tests/unit_test/skills_benchmark/skills_benchmark_build_test.py
+++ b/tests/unit_test/skills_benchmark/skills_benchmark_build_test.py
@@ -1,0 +1,459 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+
+def test_docker_build_args_reject_embedded_equals():
+    from assist_tools.skills_benchmark.skills.harness.host.build import render_agent_build_args
+
+    try:
+        render_agent_build_args({"AGENT_CLI_VERSION": "1.0=bad"})
+    except ValueError as exc:
+        assert "must not contain '='" in str(exc)
+    else:
+        raise AssertionError("Docker build arg values with embedded '=' should fail before docker build")
+
+    try:
+        render_agent_build_args({"AGENT=CLI_VERSION": "1.0"})
+    except ValueError as exc:
+        assert "key must not contain '='" in str(exc)
+    else:
+        raise AssertionError("Docker build arg keys with embedded '=' should fail before docker build")
+
+
+def test_prepare_build_context_cleans_temp_dir_on_internal_failure(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host import build
+
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.setattr(build, "copy_harness", lambda _src, _dst: (_ for _ in ()).throw(RuntimeError("copy failed")))
+
+    try:
+        build.prepare_build_context()
+    except RuntimeError as exc:
+        assert "copy failed" in str(exc)
+    else:
+        raise AssertionError("prepare_build_context should propagate internal failures")
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_prepare_build_context_stages_assist_tools_for_docker_copy(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host import build
+
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+
+    context = build.prepare_build_context()
+    try:
+        assert (context / "assist_tools" / "__init__.py").is_file()
+        assert (context / "assist_tools" / "skills_benchmark" / "__init__.py").is_file()
+        assert (context / "assist_tools" / "skills_benchmark" / "config" / "agents" / "codex.yaml").is_file()
+        assert (
+            context
+            / "assist_tools"
+            / "skills_benchmark"
+            / "skills"
+            / "harness"
+            / "container"
+            / "sdk_skills_setup.py"
+        ).is_file()
+        dockerignore = (context / ".dockerignore").read_text(encoding="utf-8")
+        assert "!assist_tools/" in dockerignore
+        assert "!assist_tools/**" in dockerignore
+    finally:
+        build.shutil.rmtree(context, ignore_errors=True)
+
+
+def test_latest_sdk_wheel_skips_stat_failures(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.host import build
+
+    stale = tmp_path / "nvflare-0.0.1-py3-none-any.whl"
+    current = tmp_path / "nvflare-0.0.2-py3-none-any.whl"
+    baseline = tmp_path / "nvflare-0.0.3-no_skills-py3-none-any.whl"
+    stale.write_text("stale\n", encoding="utf-8")
+    current.write_text("current\n", encoding="utf-8")
+    baseline.write_text("baseline\n", encoding="utf-8")
+    original_stat = type(stale).stat
+
+    def flaky_stat(path):
+        if path == stale:
+            raise OSError("wheel disappeared")
+        return original_stat(path)
+
+    monkeypatch.setattr(type(stale), "stat", flaky_stat)
+
+    assert build.latest_sdk_wheel(tmp_path, ("nvflare-*.whl", "nvflare_nightly-*.whl"), ("*no_skills*.whl",)) == current
+
+
+def test_nvflare_sdk_adapter_loads_build_contract():
+    from assist_tools.skills_benchmark.skills.harness.sdks.registry import load_sdk_adapter, supported_sdk_names
+
+    sdk = load_sdk_adapter("nvflare-profile")
+    skills = sdk.wheel_variant("skills")
+    baseline = sdk.wheel_variant("baseline")
+    build_args = sdk.docker_build_args()
+    source = sdk.source(repo_root=Path(__file__).resolve().parents[3], home=Path.home())
+
+    assert sdk.name == "nvflare"
+    assert "nvflare-profile" in supported_sdk_names()
+    assert sdk.wheel_build().build_type == "uv_wheel"
+    assert source.source_type == "repo"
+    assert source.repo_markers == ("pyproject.toml", "nvflare/")
+    assert sdk.build_env_name == "NVFLARE_PACKAGE_AGENT_SKILLS"
+    assert skills.build_env_value == "1"
+    assert skills.wheel_exclude_globs == ("*no_skills*.whl",)
+    assert baseline.build_env_value == "0"
+    assert baseline.wheel_globs == ("*no_skills*.whl",)
+    assert build_args["SKILLS_INSTALL_COMMAND"].startswith("nvflare --format json agent skills install")
+
+
+def test_configurable_sdk_adapter_loads_non_nvflare_contract(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.sdks.config import ConfigurableSdkAdapter
+
+    config_path = tmp_path / "example_sdk.yaml"
+    config_path.write_text(
+        """
+name: example
+display_name: Example SDK
+package_name: example-sdk
+import_name: example_sdk
+source:
+  type: repo
+  path: "{repo_root}"
+  markers:
+    - pyproject.toml
+build:
+  type: uv_wheel
+  env_name: EXAMPLE_PACKAGE_SKILLS
+  variants:
+    skills:
+      label: skills
+      build_env_value: "with"
+      wheel_globs:
+        - example_sdk-*.whl
+    baseline:
+      label: baseline
+      build_env_value: "without"
+      wheel_globs:
+        - example_sdk_baseline-*.whl
+docker:
+  version_command: example-sdk --version
+skills:
+  setup:
+    type: command
+    install_command: example-sdk skills install --agent "${BENCHMARK_DOCKER_AGENT}" --target "${BENCHMARK_AGENT_HOME}/skills"
+    list_command: example-sdk skills list --agent "${BENCHMARK_DOCKER_AGENT}" --target "${BENCHMARK_AGENT_HOME}/skills"
+    install_output: skills_build_install.json
+    list_output: skills_list.json
+    expected_source: local_sdk_wheel
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    sdk = ConfigurableSdkAdapter(config_path)
+    skills = sdk.wheel_variant("skills")
+    baseline = sdk.wheel_variant("baseline")
+    build_args = sdk.docker_build_args()
+    source = sdk.source(repo_root=tmp_path, home=tmp_path)
+
+    assert sdk.name == "example"
+    assert sdk.package_name == "example-sdk"
+    assert sdk.import_name == "example_sdk"
+    assert sdk.wheel_build().build_type == "uv_wheel"
+    assert source.source_type == "repo"
+    assert source.repo_path == tmp_path
+    assert sdk.build_env_name == "EXAMPLE_PACKAGE_SKILLS"
+    assert skills.build_env_value == "with"
+    assert baseline.build_env_value == "without"
+    assert build_args["SDK_PACKAGE_NAME"] == "example-sdk"
+    assert build_args["SKILLS_SETUP_TYPE"] == "command"
+    assert build_args["SKILLS_INSTALL_OUTPUT"] == "skills_build_install.json"
+
+
+def test_configurable_sdk_adapter_reports_unknown_source_placeholder(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.sdks.config import ConfigurableSdkAdapter
+
+    config_path = tmp_path / "example_sdk.yaml"
+    config_path.write_text(
+        """
+name: example
+display_name: Example SDK
+package_name: example-sdk
+import_name: example_sdk
+source:
+  type: repo
+  path: "{missing_root}"
+  markers:
+    - pyproject.toml
+build:
+  type: uv_wheel
+  variants:
+    skills:
+      wheel_globs:
+        - example_sdk-*.whl
+    baseline:
+      wheel_globs:
+        - example_sdk_baseline-*.whl
+docker:
+  version_command: example-sdk --version
+skills:
+  setup:
+    type: none
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    sdk = ConfigurableSdkAdapter(config_path)
+
+    try:
+        sdk.source(repo_root=tmp_path, home=tmp_path)
+    except ValueError as exc:
+        assert str(config_path) in str(exc)
+        assert "unknown placeholder {missing_root} in source.path" in str(exc)
+    else:
+        raise AssertionError("unknown SDK source placeholders should fail with a clear error")
+
+
+def test_configurable_sdk_adapter_loads_wheel_source_contract(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.sdks.config import ConfigurableSdkAdapter
+
+    skills_wheel = tmp_path / "example_sdk-1.0.0-py3-none-any.whl"
+    baseline_wheel = tmp_path / "example_sdk_baseline-1.0.0-py3-none-any.whl"
+    skills_wheel.write_bytes(b"skills wheel")
+    baseline_wheel.write_bytes(b"baseline wheel")
+    config_path = tmp_path / "example_sdk_wheels.yaml"
+    config_path.write_text(
+        f"""
+name: example
+display_name: Example SDK
+package_name: example-sdk
+import_name: example_sdk
+source:
+  type: wheels
+  wheels:
+    skills: {skills_wheel}
+    baseline: {baseline_wheel}
+build:
+  type: provided_wheels
+  variants:
+    skills:
+      label: skills
+      build_env_value: "with"
+      wheel_globs:
+        - example_sdk-*.whl
+    baseline:
+      label: baseline
+      build_env_value: "without"
+      wheel_globs:
+        - example_sdk_baseline-*.whl
+docker:
+  version_command: example-sdk --version
+skills:
+  setup:
+    type: command
+    install_command: example-sdk skills install --agent "${{BENCHMARK_DOCKER_AGENT}}" --target "${{BENCHMARK_AGENT_HOME}}/skills"
+    list_command: example-sdk skills list --agent "${{BENCHMARK_DOCKER_AGENT}}" --target "${{BENCHMARK_AGENT_HOME}}/skills"
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    sdk = ConfigurableSdkAdapter(config_path)
+    source = sdk.source(repo_root=tmp_path, home=tmp_path)
+
+    assert source.source_type == "wheels"
+    assert sdk.wheel_build().build_type == "provided_wheels"
+    assert source.wheel_paths == {"skills": skills_wheel, "baseline": baseline_wheel}
+
+
+def test_wheel_source_stages_configured_wheel_without_repo_build(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host import build
+    from assist_tools.skills_benchmark.skills.harness.sdks.config import ConfigurableSdkAdapter
+
+    skills_wheel = tmp_path / "example_sdk-1.0.0-py3-none-any.whl"
+    baseline_wheel = tmp_path / "example_sdk_baseline-1.0.0-py3-none-any.whl"
+    skills_wheel.write_bytes(b"skills wheel")
+    baseline_wheel.write_bytes(b"baseline wheel")
+    config_path = tmp_path / "example_sdk_wheels.yaml"
+    config_path.write_text(
+        f"""
+name: example
+display_name: Example SDK
+package_name: example-sdk
+import_name: example_sdk
+source:
+  type: wheels
+  wheels:
+    skills: {skills_wheel}
+    baseline: {baseline_wheel}
+build:
+  type: provided_wheels
+  variants:
+    skills:
+      label: skills
+      build_env_value: "with"
+      wheel_globs:
+        - example_sdk-*.whl
+    baseline:
+      label: baseline
+      build_env_value: "without"
+      wheel_globs:
+        - example_sdk_baseline-*.whl
+docker:
+  version_command: example-sdk --version
+skills:
+  setup:
+    type: command
+    install_command: example-sdk skills install --agent "${{BENCHMARK_DOCKER_AGENT}}" --target "${{BENCHMARK_AGENT_HOME}}/skills"
+    list_command: example-sdk skills list --agent "${{BENCHMARK_DOCKER_AGENT}}" --target "${{BENCHMARK_AGENT_HOME}}/skills"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    sdk = ConfigurableSdkAdapter(config_path)
+    source = build.resolve_sdk_source(sdk)
+
+    prepared = build.prepare_sdk_wheel(
+        source=source,
+        wheel_build=sdk.wheel_build(),
+        sdk=sdk,
+        variant=sdk.wheel_variant("skills"),
+        out_dir=tmp_path / "staged",
+    )
+
+    assert prepared.source_type == "wheels"
+    assert prepared.source_path == skills_wheel.resolve()
+    assert prepared.wheel.name == skills_wheel.name
+    assert prepared.wheel.read_bytes() == b"skills wheel"
+
+
+def test_copy_skills_setup_stages_profile_skills_folder(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.host import build
+    from assist_tools.skills_benchmark.skills.harness.sdks.config import ConfigurableSdkAdapter
+
+    skills_dir = tmp_path / "agent-skills"
+    skills_dir.mkdir()
+    (skills_dir / "README.md").write_text("example skill\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'example'\n", encoding="utf-8")
+    config_path = tmp_path / "example_sdk_copy_skills.yaml"
+    config_path.write_text(
+        f"""
+name: example
+display_name: Example SDK
+package_name: example-sdk
+import_name: example_sdk
+source:
+  type: repo
+  path: {tmp_path}
+  markers:
+    - pyproject.toml
+build:
+  type: uv_wheel
+  variants:
+    skills:
+      label: skills
+      build_env_value: "with"
+      wheel_globs:
+        - example_sdk-*.whl
+    baseline:
+      label: baseline
+      build_env_value: "without"
+      wheel_globs:
+        - example_sdk_baseline-*.whl
+docker:
+  version_command: example-sdk --version
+skills:
+  setup:
+    type: copy
+    source_path: {skills_dir}
+    expected_source: profile_skills_folder
+""".lstrip(),
+        encoding="utf-8",
+    )
+    sdk = ConfigurableSdkAdapter(config_path)
+    setup = build.resolve_sdk_skills_setup(sdk)
+    context = tmp_path / "context"
+    context.mkdir()
+
+    build.stage_sdk_skills_setup(context, setup)
+
+    assert setup.setup_type == "copy"
+    assert (context / "sdk_skills" / "README.md").read_text(encoding="utf-8") == "example skill\n"
+
+
+def test_container_sdk_skills_setup_copy_mode_installs_staged_folder(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container import sdk_skills_setup
+
+    staged = tmp_path / "sdk_skills"
+    staged.mkdir()
+    (staged / "README.md").write_text("example skill\n", encoding="utf-8")
+    home = tmp_path / "agent-home"
+    monkeypatch.setattr(sdk_skills_setup, "SDK_SKILLS_SOURCE", staged)
+    monkeypatch.setenv("BENCHMARK_AGENT_HOME", str(home))
+    monkeypatch.setenv("BENCHMARK_DOCKER_AGENT", "codex")
+    monkeypatch.setenv("SKILLS_SETUP_TYPE", "copy")
+    monkeypatch.setenv("SKILLS_INSTALL_OUTPUT", "install.json")
+    monkeypatch.setenv("SKILLS_LIST_OUTPUT", "list.json")
+    monkeypatch.delenv("SKILLS_LIST_COMMAND", raising=False)
+
+    assert sdk_skills_setup.main() == 0
+
+    install = json.loads((home / "install.json").read_text(encoding="utf-8"))
+    listing = json.loads((home / "list.json").read_text(encoding="utf-8"))
+    assert (home / "skills" / "README.md").read_text(encoding="utf-8") == "example skill\n"
+    assert install["mechanism"] == "copy"
+    assert install["file_count"] == 1
+    assert listing["installed"] == ["README.md"]
+
+
+def test_container_sdk_skills_setup_visible_files_skips_symlinks(tmp_path):
+    from assist_tools.skills_benchmark.skills.harness.container import sdk_skills_setup
+
+    root = tmp_path / "skills"
+    root.mkdir()
+    root.joinpath("README.md").write_text("example skill\n", encoding="utf-8")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside\n", encoding="utf-8")
+    try:
+        root.joinpath("linked.txt").symlink_to(outside)
+        root.joinpath("linked_dir").symlink_to(tmp_path, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        return
+
+    assert sdk_skills_setup.visible_files(root) == ["README.md"]
+
+
+def test_container_sdk_skills_setup_run_command_uses_non_login_shell(tmp_path, monkeypatch):
+    from assist_tools.skills_benchmark.skills.harness.container import sdk_skills_setup
+
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+
+    monkeypatch.setattr(sdk_skills_setup.subprocess, "run", fake_run)
+
+    sdk_skills_setup.run_command("example-sdk skills list", tmp_path / "out.json")
+
+    assert calls[0][0] == ["/bin/bash", "-c", "example-sdk skills list"]
+    assert calls[0][1]["check"] is True
+
+
+def test_host_common_compat_exports_are_explicit():
+    from assist_tools.skills_benchmark.skills.harness import host_common
+    from assist_tools.skills_benchmark.skills.harness.host import common
+
+    assert "parse_host_cli_options" in common.__all__
+    assert hasattr(host_common, "parse_host_cli_options")
+    assert "subprocess" not in common.__all__
+    assert not hasattr(host_common, "subprocess")


### PR DESCRIPTION
## Summary

Adds the generic skills benchmark Docker build setup, SDK/agent YAML profiles, configurable SDK/agent adapters, Dockerfile/build context handling, and build/profile tests.

## Key Scope

- Add benchmark Dockerfile and build-context configuration.
- Add SDK profile config, including `nvflare-profile`.
- Add agent profile config for Codex and Claude.
- Add configurable SDK/agent adapter plumbing used by Docker build/runtime setup.
- Add build and profile validation tests.

## Stack

This is PR 3 of 5. It is based on `flare-agent-split/02-agent-cli` / PR #11.

## Full Split Plan

| PR | Title | Branch | Base | Non-Test Files | Test Files | Non-Test Lines | Test Lines | Total Lines |
|---:|---|---|---|---:|---:|---:|---:|---:|
| 1 | Agent Skills + Checks | `flare-agent-split/01-agent-skills` | `flare-agent-split/base-main` | 41 | 8 | 5,397 | 1,321 | 6,718 |
| 2 | Agent CLI | `flare-agent-split/02-agent-cli` | PR 1 | 11 | 8 | 4,362 | 2,488 | 6,850 |
| 3 | Benchmark Docker Setup | `flare-agent-split/03-benchmark-docker-setup` | PR 2 | 29 | 3 | 4,015 | 1,417 | 5,432 |
| 4 | Skill Benchmark Runtime | `flare-agent-split/04-benchmark-runtime` | PR 3 | 25 | 5 | 9,927 | 3,654 | 13,581 |
| 5 | Benchmark Reporting | `flare-agent-split/05-benchmark-reporting` | PR 4 | 3 | 1 | 2,016 | 1,037 | 3,053 |

## Validation

- `python -m pytest tests/unit_test/tool/agent tests/unit_test/tool/agent_skill_checks tests/unit_test/skills_benchmark`
- `./runtest.sh -s`